### PR TITLE
ASC-350 Attach Raw JUnit XML Files to Test Logs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,41 +7,83 @@ Contributing
 Contributions are welcome, and they are greatly appreciated! Every little bit
 helps, and credit will always be given.
 
+------------
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `zigzag` for local development.
+Ready to contribute? Here's how to set up ``zigzag`` for local development using the handy built-in ``make`` tasks.
+If you're not using virtualenvwrapper_ then skip ahead to the `Doing it the Hard Way`_ section for detailed
+instructions.
 
-1. Fork the `zigzag` repo on GitHub.
-2. Clone your fork locally::
+Prerquisites
+------------
+
+In order to take full advantage of the built-in ``make`` tasks you must install virtualenvwrapper_ with the **system**
+Python interpreter. Also, virtualenvwrapper_ must be fully configured and a virtual environment needs to be **active**
+before running the ``make`` tasks specified in the next section.
+
+Getting Help with Make Tasks
+----------------------------
+
+Execute the following command to get a full list of ``make`` tasks::
+
+    $ make help
+
+Using Make Tasks for Development Environment Setup
+--------------------------------------------------
+
+1. Fork the ``zigzag`` repo on GitHub.
+2. Create a virtual environment using virtualenvwrapper_ if you have not created one already::
+
+    $ mkvirtualenv zigzag
+
+3. Clone your fork locally::
 
     $ git clone git@github.com:your_name_here/zigzag.git
 
-3. Install your local copy into a virtualenv. (You must have virtualenvwrapper installed) This is how you set up your fork for local development::
+4. Setup develop environment::
 
-    $ mkvirtualenv zigzag
     $ cd zigzag/
     $ make develop
 
-4. Create a branch for local development::
+5. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
+6. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
     $ make test-all
 
-6. Commit your changes and push your branch to GitHub::
+7. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
+Doing it the Hard Way
+---------------------
+
+So you're just not into virtualenvwrapper_ ? That's okay! Here is what you'll have to do to get going with development
+without having to install anything extra on the system.
+
+1. Install Python dependencies::
+
+    $ pip install -r requirements_dev.txt
+
+2. Run tests::
+
+    $ tox
+
+3. Clean-up test artifacts::
+
+    $ make clean-test
+
+-----------------------
 Pull Request Guidelines
 -----------------------
 
@@ -73,3 +115,5 @@ Clean-up the `zigzag` build artifacts and wipe the active virtualenv::
 Run a subset of tests::
 
    $ py.test tests/test_zigzag.py
+
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+lxml
 click
 bumpversion
 flake8

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 dependency_links = ['http://github.com/ryan-rs/qtest-swagger-client/tarball/master#egg=swagger-client-1.0.0']
-requirements = ['Click>=6.0', 'swagger-client']
+requirements = ['Click>=6.0', 'swagger-client', 'lxml']
 setup_requirements = ['pytest-runner']
 
 setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,8 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
-from click.testing import CliRunner
 from zigzag import cli
+from click.testing import CliRunner
 
 
 def test_cli_happy_path(single_passing_xml, mocker):

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -4,6 +4,7 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
+import re
 import pytest
 from hashlib import md5
 from zigzag import zigzag
@@ -172,12 +173,12 @@ class TestGenerateTestLogs(object):
         test_log_dict = zigzag._generate_test_logs(junit_xml)[0].to_dict()
 
         # Expectation
-        attachment_exp_name = 'junit.xml'
+        attachment_exp_name_regex = re.compile(r'^junit_.+\.xml$')
         attachment_exp_content_type = 'application/xml'
         attachment_exp_data_md5 = '45f29a8da0b0981e20c2c8562081280a'
 
         # Test
-        assert attachment_exp_name == test_log_dict['attachments'][0]['name']
+        assert attachment_exp_name_regex.match(test_log_dict['attachments'][0]['name']) is not None
         assert attachment_exp_content_type == test_log_dict['attachments'][0]['content_type']
         assert attachment_exp_data_md5 == md5(test_log_dict['attachments'][0]['data'].encode('UTF-8')).hexdigest()
 

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -51,6 +51,18 @@ class TestLoadingInputJunitXMLFile(object):
         with pytest.raises(RuntimeError):
             zigzag._load_input_file(bad_junit_root)
 
+    def test_exceeds_max_file_size(self, flat_all_passing_xml, mocker):
+        """Verify that XML files that exceed the max file size are rejected"""
+        # Setup
+        file_size = 52428801
+
+        # Mock
+        mocker.patch('os.path.getsize', return_value=file_size)
+
+        # Test
+        with pytest.raises(RuntimeError):
+            zigzag._load_input_file(flat_all_passing_xml)
+
 
 class TestGenerateTestLogs(object):
     """Test cases for the '_generate_test_logs' function"""

--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -65,6 +65,7 @@ def _generate_test_logs(junit_xml):
 
     serialized_junit_xml = etree.tostring(junit_xml, encoding='UTF-8', xml_declaration=True)
     testsuite_props = {p.attrib['name']: p.attrib['value'] for p in junit_xml.findall('./properties/property')}
+    date_time_now = datetime.utcnow()
     test_logs = []
 
     for testcase_xml in junit_xml.findall('testcase'):
@@ -79,11 +80,11 @@ def _generate_test_logs(junit_xml):
 
         test_log.name = TESTCASE_NAME_RGX.match(testcase_xml.attrib['name']).group(1)
         test_log.status = testcase_status
-        test_log.module_names = [testsuite_props['GIT_BRANCH']]                      # GIT_BRANCH == RPC release
-        test_log.exe_start_date = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')   # UTC timezone 'Zulu'
-        test_log.exe_end_date = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')     # UTC timezone 'Zulu'
+        test_log.module_names = [testsuite_props['GIT_BRANCH']]                  # GIT_BRANCH == RPC release
+        test_log.exe_start_date = date_time_now.strftime('%Y-%m-%dT%H:%M:%SZ')   # UTC timezone 'Zulu'
+        test_log.exe_end_date = date_time_now.strftime('%Y-%m-%dT%H:%M:%SZ')     # UTC timezone 'Zulu'
         test_log.attachments = \
-            [swagger_client.AttachmentResource(name='junit.xml',
+            [swagger_client.AttachmentResource(name="junit_{}.xml".format(date_time_now.strftime('%Y-%m-%dT%H-%M')),
                                                content_type='application/xml',
                                                data=b64encode(serialized_junit_xml).decode('UTF-8'),
                                                author={})]

--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -3,6 +3,7 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
+import os
 import re
 import swagger_client
 from lxml import etree
@@ -15,6 +16,7 @@ from swagger_client.rest import ApiException
 # Globals
 # ======================================================================================================================
 TESTCASE_NAME_RGX = re.compile(r'(\w+)(\[.+\])')
+MAX_FILE_SIZE = 52428800
 
 
 # ======================================================================================================================
@@ -36,8 +38,11 @@ def _load_input_file(file_path):
     root_element = "testsuite"
 
     try:
+        if os.path.getsize(file_path) > MAX_FILE_SIZE:
+            raise RuntimeError('Input file "{}" is larger than allowed max file size!'.format(file_path))
+
         junit_xml = etree.parse(file_path).getroot()
-    except IOError:
+    except (IOError, OSError):
         raise RuntimeError('Invalid path "{}" for JUnitXML results file!'.format(file_path))
     except etree.ParseError:
         raise RuntimeError('The file "{}" does not contain valid XML!'.format(file_path))


### PR DESCRIPTION
Add a "junit.xml" file attachment to each test log so that raw results can be
inspected if qTest shows a difference in results.