### PR TITLE
 ASC-348 Add Build Info to qTest Results 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,15 +18,18 @@ def single_passing_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852">
@@ -52,15 +55,18 @@ def single_fail_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
             name="test_fail[ansible://localhost]" time="0.00335693359375">
@@ -93,15 +99,18 @@ def single_error_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="20"
             name="test_error[ansible://localhost]" time="0.00208067893982">
@@ -135,15 +144,18 @@ def single_skip_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="24"
             name="test_skip[ansible://localhost]" time="0.00197100639343">
@@ -172,15 +184,18 @@ def flat_all_passing_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass1[ansible://localhost]" time="0.00372695922852">
@@ -230,15 +245,18 @@ def flat_mix_status_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="1" failures="1" name="pytest" skips="1" tests="4" time="1.901">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="12"
             name="test_pass[ansible://localhost]" time="0.0034921169281">
@@ -300,15 +318,18 @@ def suite_mix_status_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="1" failures="1" name="pytest" skips="1" tests="4" time="1.853">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default.TestClass" file="tests/test_default.py" line="35"
             name="test_pass[ansible://localhost]" time="0.00357985496521">
@@ -402,15 +423,18 @@ def missing_test_id_xml(tmpdir_factory):
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             <properties>
-                <property name="JENKINS_CONSOLE_LOG_URL" value="Unknown"/>
-                <property name="SCENARIO" value="Unknown"/>
-                <property name="ACTION" value="Unknown"/>
-                <property name="IMAGE" value="Unknown"/>
+                <property name="BUILD_URL" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
                 <property name="OS_ARTIFACT_SHA" value="Unknown"/>
                 <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="GIT_REPO" value="Unknown"/>
-                <property name="GIT_BRANCH" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
             </properties>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852"/>

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -82,6 +82,8 @@ class TestGenerateTestLogs(object):
         test_name = 'test_pass'
         test_log_exp = {'name': test_name,
                         'status': 'PASSED',
+                        'build_url': 'Unknown',
+                        'build_number': 'Unknown',
                         'module_names': ['Unknown'],
                         'automation_content': '1'}
 
@@ -103,6 +105,8 @@ class TestGenerateTestLogs(object):
         test_name = 'test_fail'
         test_log_exp = {'name': test_name,
                         'status': 'FAILED',
+                        'build_url': 'Unknown',
+                        'build_number': 'Unknown',
                         'module_names': ['Unknown'],
                         'automation_content': '1'}
 
@@ -124,6 +128,8 @@ class TestGenerateTestLogs(object):
         test_name = 'test_error'
         test_log_exp = {'name': test_name,
                         'status': 'FAILED',
+                        'build_url': 'Unknown',
+                        'build_number': 'Unknown',
                         'module_names': ['Unknown'],
                         'automation_content': '1'}
 
@@ -145,6 +151,8 @@ class TestGenerateTestLogs(object):
         test_name = 'test_skip'
         test_log_exp = {'name': test_name,
                         'status': 'SKIPPED',
+                        'build_url': 'Unknown',
+                        'build_number': 'Unknown',
                         'module_names': ['Unknown'],
                         'automation_content': '1'}
 
@@ -175,7 +183,7 @@ class TestGenerateTestLogs(object):
         # Expectation
         attachment_exp_name_regex = re.compile(r'^junit_.+\.xml$')
         attachment_exp_content_type = 'application/xml'
-        attachment_exp_data_md5 = '45f29a8da0b0981e20c2c8562081280a'
+        attachment_exp_data_md5 = '21a479062af4891d07dcae6d86666adc'
 
         # Test
         assert attachment_exp_name_regex.match(test_log_dict['attachments'][0]['name']) is not None
@@ -201,18 +209,26 @@ class TestGenerateAutoRequest(object):
         prop_value = 'Unknown'
         test_logs_exp = [{'name': 'test_pass',
                           'status': 'PASSED',
+                          'build_url': 'Unknown',
+                          'build_number': 'Unknown',
                           'module_names': [prop_value],
                           'automation_content': '1'},
                          {'name': 'test_fail',
                           'status': 'FAILED',
+                          'build_url': 'Unknown',
+                          'build_number': 'Unknown',
                           'module_names': [prop_value],
                           'automation_content': '1'},
                          {'name': 'test_error',
                           'status': 'FAILED',
+                          'build_url': 'Unknown',
+                          'build_number': 'Unknown',
                           'module_names': [prop_value],
                           'automation_content': '1'},
                          {'name': 'test_skip',
                           'status': 'SKIPPED',
+                          'build_url': 'Unknown',
+                          'build_number': 'Unknown',
                           'module_names': [prop_value],
                           'automation_content': '1'}]
 

--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -80,7 +80,9 @@ def _generate_test_logs(junit_xml):
 
         test_log.name = TESTCASE_NAME_RGX.match(testcase_xml.attrib['name']).group(1)
         test_log.status = testcase_status
-        test_log.module_names = [testsuite_props['GIT_BRANCH']]                  # GIT_BRANCH == RPC release
+        test_log.build_url = testsuite_props['BUILD_URL']
+        test_log.build_number = testsuite_props['BUILD_NUMBER']
+        test_log.module_names = [testsuite_props['RPC_PRODUCT_RELEASE']]         # RPC Release Codename (e.g. Queens)
         test_log.exe_start_date = date_time_now.strftime('%Y-%m-%dT%H:%M:%SZ')   # UTC timezone 'Zulu'
         test_log.exe_end_date = date_time_now.strftime('%Y-%m-%dT%H:%M:%SZ')     # UTC timezone 'Zulu'
         test_log.attachments = \


### PR DESCRIPTION
Attach "build_url" and "build_number" to qTest test log results. Also,
refactored the expected environment variables to match the changes in
"pytest-rpc" plug-in.