### PR TITLE
ASC-368 Validate JUnitXML Against XSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ clean-test: ## remove test and coverage artifacts
 
 clean-venv: check-venv ## remove all packages from current virtual environment
 	@pip uninstall -y swagger-client || echo "Skipping uninstall of swagger-client"
+	@pip uninstall -y pytest-rpc || echo "Skipping uninstall of pytest-rpc"
 	@source virtualenvwrapper.sh && wipeenv || echo "Skipping wipe of environment"
 
 lint: ## check style with flake8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,6 @@ coverage
 pytest
 pytest-runner
 pytest-mock
+ipython
 -e git+https://github.com/ryan-rs/qtest-swagger-client.git@master#egg=swagger-client-1.0.0
+-e git+https://github.com/rcbops/pytest-rpc.git@master#egg=pytest-rpc-0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-dependency_links = ['http://github.com/ryan-rs/qtest-swagger-client/tarball/master#egg=swagger-client-1.0.0']
-requirements = ['Click>=6.0', 'swagger-client', 'lxml']
+dependency_links = ['http://github.com/ryan-rs/qtest-swagger-client/tarball/master#egg=swagger-client-1.0.0',
+                    'http://github.com/rcbops/pytest-rpc/tarball/master#egg=pytest-rpc-0.4.0']
+requirements = ['Click>=6.0', 'lxml', 'swagger-client', 'pytest-rpc']
 setup_requirements = ['pytest-runner']
 
 setup(
@@ -46,6 +47,6 @@ setup(
     packages=find_packages(include=['zigzag']),
     setup_requires=setup_requirements,
     url='https://github.com/rcbops/zigzag',
-    version='0.5.0',
+    version='0.6.0',
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ DEFAULT_TESTCASE_PROPERTIES = \
                 <properties>
                     <property name="test_id" value="1"/>
                     <property name="start_time" value="2018-04-10T21:38:18Z"/>
-                    <property name="end_time" value="2018-04-10T21:38:18Z"/>
+                    <property name="end_time" value="2018-04-10T21:38:19Z"/>
                 </properties>
     """
 
@@ -321,6 +321,26 @@ def bad_junit_root(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
+def missing_testcase_properties_xml(tmpdir_factory):
+    """JUnitXML sample representing a test case that is missing the test case "properties" element."""
+
+    filename = tmpdir_factory.mktemp('data').join('missing_testcase_properties.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
+            name="test_pass[ansible://localhost]" time="0.00372695922852"/>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
 def missing_test_id_xml(tmpdir_factory):
     """JUnitXML sample representing a test case that has a missing test id property element."""
 
@@ -331,6 +351,45 @@ def missing_test_id_xml(tmpdir_factory):
             {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852"/>
+                <properties>
+                    <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                    <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                    <property name="end_time" value="2018-04-10T21:38:19Z"/>
+                </properties>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
+def missing_build_url_xml(tmpdir_factory):
+    """JUnitXML sample representing a test suite that is missing the "BUILD_URL" property."""
+
+    filename = tmpdir_factory.mktemp('data').join('missing_build_url.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            <properties>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="BUILD_NUMBER" value="Unknown"/>
+                <property name="RE_JOB_ACTION" value="Unknown"/>
+                <property name="RE_JOB_IMAGE" value="Unknown"/>
+                <property name="RE_JOB_SCENARIO" value="Unknown"/>
+                <property name="RE_JOB_BRANCH" value="Unknown"/>
+                <property name="RPC_RELEASE" value="Unknown"/>
+                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
+                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
+                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
+                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
+                <property name="REPO_URL" value="Unknown"/>
+            </properties>
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
+            name="test_pass[ansible://localhost]" time="0.00372695922852"/>
+                {testcase_properties}
         </testsuite>
         """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,10 @@ import pytest
 
 
 # ======================================================================================================================
-# Fixtures
+# Globals
 # ======================================================================================================================
-@pytest.fixture(scope='session')
-def single_passing_xml(tmpdir_factory):
-    """JUnitXML sample representing a single passing test."""
-
-    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
-    junit_xml = \
-        """<?xml version="1.0" encoding="utf-8"?>
-        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+DEFAULT_GLOBAL_PROPERTIES = \
+    """
             <properties>
                 <property name="BUILD_URL" value="Unknown"/>
                 <property name="BUILD_NUMBER" value="Unknown"/>
@@ -31,14 +25,36 @@ def single_passing_xml(tmpdir_factory):
                 <property name="APT_ARTIFACT_SHA" value="Unknown"/>
                 <property name="REPO_URL" value="Unknown"/>
             </properties>
-            <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
-            name="test_pass[ansible://localhost]" time="0.00372695922852">
+    """
+
+DEFAULT_TESTCASE_PROPERTIES = \
+    """
                 <properties>
                     <property name="test_id" value="1"/>
+                    <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                    <property name="end_time" value="2018-04-10T21:38:18Z"/>
                 </properties>
+    """
+
+
+# ======================================================================================================================
+# Fixtures
+# ======================================================================================================================
+@pytest.fixture(scope='session')
+def single_passing_xml(tmpdir_factory):
+    """JUnitXML sample representing a single passing test."""
+
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
+            name="test_pass[ansible://localhost]" time="0.00372695922852">
+                {testcase_properties}
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -54,22 +70,10 @@ def single_fail_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
             name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
                 <failure message="assert False">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
 
             def test_fail(host):
@@ -77,12 +81,9 @@ def single_fail_xml(tmpdir_factory):
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -98,22 +99,10 @@ def single_error_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="20"
             name="test_error[ansible://localhost]" time="0.00208067893982">
+                {testcase_properties}
                 <error message="test setup failure">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
 
             @pytest.fixture
@@ -122,12 +111,9 @@ def single_error_xml(tmpdir_factory):
         E       RuntimeError: oops
 
         tests/test_default.py:10: RuntimeError</error>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -143,31 +129,16 @@ def single_skip_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="24"
             name="test_skip[ansible://localhost]" time="0.00197100639343">
+                {testcase_properties}
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -183,52 +154,29 @@ def flat_all_passing_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass1[ansible://localhost]" time="0.00372695922852">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="12"
             name="test_pass2[ansible://localhost]" time="0.00341415405273">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="15"
             name="test_pass3[ansible://localhost]" time="0.00363945960999">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="18"
             name="test_pass4[ansible://localhost]" time="0.00314617156982">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="21"
             name="test_pass5[ansible://localhost]" time="0.00332307815552">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -244,28 +192,14 @@ def flat_mix_status_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="1" failures="1" name="pytest" skips="1" tests="4" time="1.901">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="12"
             name="test_pass[ansible://localhost]" time="0.0034921169281">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
             name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
                 <failure message="assert False">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
 
             def test_fail(host):
@@ -273,12 +207,10 @@ def flat_mix_status_xml(tmpdir_factory):
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="20"
             name="test_error[ansible://localhost]" time="0.00208067893982">
+                {testcase_properties}
                 <error message="test setup failure">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
 
             @pytest.fixture
@@ -287,21 +219,16 @@ def flat_mix_status_xml(tmpdir_factory):
         E       RuntimeError: oops
 
         tests/test_default.py:10: RuntimeError</error>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="24"
             name="test_skip[ansible://localhost]" time="0.00197100639343">
+                {testcase_properties}
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -317,28 +244,14 @@ def suite_mix_status_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="1" failures="1" name="pytest" skips="1" tests="4" time="1.853">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default.TestClass" file="tests/test_default.py" line="35"
             name="test_pass[ansible://localhost]" time="0.00357985496521">
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
+                {testcase_properties}
             </testcase>
             <testcase classname="tests.test_default.TestClass" file="tests/test_default.py" line="38"
             name="test_fail[ansible://localhost]" time="0.00310778617859">
+                {testcase_properties}
                 <failure message="assert False">self = &lt;test_default.TestClass object at 0x7fb9c7b9a790&gt;
         host = &lt;testinfra.host.Host object at 0x7fb9c7c18d10&gt;
 
@@ -347,12 +260,10 @@ def suite_mix_status_xml(tmpdir_factory):
         E       assert False
 
         tests/test_default.py:40: AssertionError</failure>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
             <testcase classname="tests.test_default.TestClass" file="tests/test_default.py" line="41"
             name="test_error[ansible://localhost]" time="0.00223517417908">
+                {testcase_properties}
                 <error message="test setup failure">self = &lt;test_default.TestClass object at 0x7fb9cb5b7190&gt;
         host = &lt;testinfra.host.Host object at 0x7fb9c7c18d10&gt;
 
@@ -362,21 +273,16 @@ def suite_mix_status_xml(tmpdir_factory):
         E       RuntimeError: oops
 
         tests/test_default.py:34: RuntimeError</error>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
             <testcase classname="tests.test_default.TestClass" file="tests/test_default.py" line="44"
             name="test_skip[ansible://localhost]" time="0.00199604034424">
+                {testcase_properties}
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:44: &lt;py._xmlgen.raw object at 0x7fb9c904d190&gt;
                 </skipped>
-                <properties>
-                    <property name="test_id" value="1"/>
-                </properties>
             </testcase>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -422,24 +328,11 @@ def missing_test_id_xml(tmpdir_factory):
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
-            <properties>
-                <property name="BUILD_URL" value="Unknown"/>
-                <property name="BUILD_NUMBER" value="Unknown"/>
-                <property name="RE_JOB_ACTION" value="Unknown"/>
-                <property name="RE_JOB_IMAGE" value="Unknown"/>
-                <property name="RE_JOB_SCENARIO" value="Unknown"/>
-                <property name="RE_JOB_BRANCH" value="Unknown"/>
-                <property name="RPC_RELEASE" value="Unknown"/>
-                <property name="RPC_PRODUCT_RELEASE" value="Unknown"/>
-                <property name="OS_ARTIFACT_SHA" value="Unknown"/>
-                <property name="PYTHON_ARTIFACT_SHA" value="Unknown"/>
-                <property name="APT_ARTIFACT_SHA" value="Unknown"/>
-                <property name="REPO_URL" value="Unknown"/>
-            </properties>
+            {global_properties}
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852"/>
         </testsuite>
-        """
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -52,6 +52,13 @@ class TestLoadingInputJunitXMLFile(object):
         with pytest.raises(RuntimeError):
             zigzag._load_input_file(bad_junit_root)
 
+    def test_missing_test_id_xml(self, missing_test_id_xml):
+        """Verify that JUnitXML that is missing the 'test_id" test case property causes a RuntimeError."""
+
+        # Test
+        with pytest.raises(RuntimeError):
+            zigzag._load_input_file(missing_test_id_xml)
+
     def test_exceeds_max_file_size(self, flat_all_passing_xml, mocker):
         """Verify that XML files that exceed the max file size are rejected"""
         # Setup
@@ -160,16 +167,6 @@ class TestGenerateTestLogs(object):
         for exp in test_log_exp:
             assert test_log_exp[exp] == test_log_dict[exp]
 
-    def test_missing_test_id_xml(self, missing_test_id_xml):
-        """Verify that JUnitXML that is missing the 'test_id" test case property causes a RuntimeError."""
-
-        # Setup
-        junit_xml = zigzag._load_input_file(missing_test_id_xml)
-
-        # Test
-        with pytest.raises(RuntimeError):
-            zigzag._generate_test_logs(junit_xml)
-
     def test_junit_xml_attachment(self, single_passing_xml):
         """Verify that a valid qTest 'AutomationTestLogResource' swagger model is generated with the raw JUnitXML
         file included as an attachment.
@@ -183,7 +180,7 @@ class TestGenerateTestLogs(object):
         # Expectation
         attachment_exp_name_regex = re.compile(r'^junit_.+\.xml$')
         attachment_exp_content_type = 'application/xml'
-        attachment_exp_data_md5 = '21a479062af4891d07dcae6d86666adc'
+        attachment_exp_data_md5 = '9dcbf8d31713a27d1d7a2002845975a7'
 
         # Test
         assert attachment_exp_name_regex.match(test_log_dict['attachments'][0]['name']) is not None

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -52,8 +52,22 @@ class TestLoadingInputJunitXMLFile(object):
         with pytest.raises(RuntimeError):
             zigzag._load_input_file(bad_junit_root)
 
+    def test_missing_build_url_xml(self, missing_build_url_xml):
+        """Verify that JUnitXML that is missing the test suite 'BUILD_URL' property element causes a RuntimeError."""
+
+        # Test
+        with pytest.raises(RuntimeError):
+            zigzag._load_input_file(missing_build_url_xml)
+
+    def test_missing_testcase_properties_xml(self, missing_testcase_properties_xml):
+        """Verify that JUnitXML that is missing the test case 'properties' element causes a RuntimeError."""
+
+        # Test
+        with pytest.raises(RuntimeError):
+            zigzag._load_input_file(missing_testcase_properties_xml)
+
     def test_missing_test_id_xml(self, missing_test_id_xml):
-        """Verify that JUnitXML that is missing the 'test_id" test case property causes a RuntimeError."""
+        """Verify that JUnitXML that is missing the 'test_id' test case property causes a RuntimeError."""
 
         # Test
         with pytest.raises(RuntimeError):
@@ -92,7 +106,9 @@ class TestGenerateTestLogs(object):
                         'build_url': 'Unknown',
                         'build_number': 'Unknown',
                         'module_names': ['Unknown'],
-                        'automation_content': '1'}
+                        'automation_content': '1',
+                        'exe_start_date': '2018-04-10T21:38:18Z',
+                        'exe_end_date': '2018-04-10T21:38:19Z'}
 
         # Test
         for exp in test_log_exp:
@@ -115,7 +131,9 @@ class TestGenerateTestLogs(object):
                         'build_url': 'Unknown',
                         'build_number': 'Unknown',
                         'module_names': ['Unknown'],
-                        'automation_content': '1'}
+                        'automation_content': '1',
+                        'exe_start_date': '2018-04-10T21:38:18Z',
+                        'exe_end_date': '2018-04-10T21:38:19Z'}
 
         # Test
         for exp in test_log_exp:
@@ -138,7 +156,9 @@ class TestGenerateTestLogs(object):
                         'build_url': 'Unknown',
                         'build_number': 'Unknown',
                         'module_names': ['Unknown'],
-                        'automation_content': '1'}
+                        'automation_content': '1',
+                        'exe_start_date': '2018-04-10T21:38:18Z',
+                        'exe_end_date': '2018-04-10T21:38:19Z'}
 
         # Test
         for exp in test_log_exp:
@@ -161,7 +181,9 @@ class TestGenerateTestLogs(object):
                         'build_url': 'Unknown',
                         'build_number': 'Unknown',
                         'module_names': ['Unknown'],
-                        'automation_content': '1'}
+                        'automation_content': '1',
+                        'exe_start_date': '2018-04-10T21:38:18Z',
+                        'exe_end_date': '2018-04-10T21:38:19Z'}
 
         # Test
         for exp in test_log_exp:
@@ -180,7 +202,7 @@ class TestGenerateTestLogs(object):
         # Expectation
         attachment_exp_name_regex = re.compile(r'^junit_.+\.xml$')
         attachment_exp_content_type = 'application/xml'
-        attachment_exp_data_md5 = '9dcbf8d31713a27d1d7a2002845975a7'
+        attachment_exp_data_md5 = '2307a9603b0eb70c45058dc4fc44ad91'
 
         # Test
         assert attachment_exp_name_regex.match(test_log_dict['attachments'][0]['name']) is not None
@@ -209,25 +231,33 @@ class TestGenerateAutoRequest(object):
                           'build_url': 'Unknown',
                           'build_number': 'Unknown',
                           'module_names': [prop_value],
-                          'automation_content': '1'},
+                          'automation_content': '1',
+                          'exe_start_date': '2018-04-10T21:38:18Z',
+                          'exe_end_date': '2018-04-10T21:38:19Z'},
                          {'name': 'test_fail',
                           'status': 'FAILED',
                           'build_url': 'Unknown',
                           'build_number': 'Unknown',
                           'module_names': [prop_value],
-                          'automation_content': '1'},
+                          'automation_content': '1',
+                          'exe_start_date': '2018-04-10T21:38:18Z',
+                          'exe_end_date': '2018-04-10T21:38:19Z'},
                          {'name': 'test_error',
                           'status': 'FAILED',
                           'build_url': 'Unknown',
                           'build_number': 'Unknown',
                           'module_names': [prop_value],
-                          'automation_content': '1'},
+                          'automation_content': '1',
+                          'exe_start_date': '2018-04-10T21:38:18Z',
+                          'exe_end_date': '2018-04-10T21:38:19Z'},
                          {'name': 'test_skip',
                           'status': 'SKIPPED',
                           'build_url': 'Unknown',
                           'build_number': 'Unknown',
                           'module_names': [prop_value],
-                          'automation_content': '1'}]
+                          'automation_content': '1',
+                          'exe_start_date': '2018-04-10T21:38:18Z',
+                          'exe_end_date': '2018-04-10T21:38:19Z'}]
 
         # Test
         for x in range(len(auto_req_dict['test_logs'])):

--- a/zigzag/__init__.py
+++ b/zigzag/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """rcbops"""
 __email__ = 'rcb-deploy@lists.rackspace.com'
-__version__ = '0.5.0'
+__version__ = '0.6.0'


### PR DESCRIPTION
Before loading processing XML files, zigzag will first check compliance with
the XSD from the "pytest-rpc" project.

Bumped the version to 0.6.0.