### PR TITLE
ASC-392 Pretty Print XML on Schema Failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,7 +301,7 @@ def flat_mix_status_xml(tmpdir_factory):
 
 @pytest.fixture(scope='session')
 def bad_xml(tmpdir_factory):
-    """JUnitXML sample representing all passing tests."""
+    """JUnitXML sample representing invalid XML."""
 
     filename = tmpdir_factory.mktemp('data').join('bad.xml').strpath
     junit_xml = "Totally Bogus Content"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ def test_cli_missing_api_token(single_passing_xml, mocker):
 
     # Expectation
     job_id = '54321'
+    error_msg_exp = 'The "QTEST_API_TOKEN" environment variable is not defined!'
 
     # Mock
     mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
@@ -54,5 +55,31 @@ def test_cli_missing_api_token(single_passing_xml, mocker):
     # Test
     result = runner.invoke(cli.main, args=cli_arguments)
     assert 1 == result.exit_code
-    assert 'The "QTEST_API_TOKEN" environment variable is not defined!' in result.output
+    assert error_msg_exp in result.output
+    assert 'Failed!' in result.output
+
+
+def test_cli_pprint_on_fail(missing_test_id_xml, mocker):
+    """Verify that the CLI will allow the user to set the '--pprint-on-fail' flag for debug printing."""
+
+    # Setup
+    env_vars = {'QTEST_API_TOKEN': 'valid_token'}
+    project_id = '12345'
+    test_cycle = 'CL-1'
+    job_id = '54321'
+
+    runner = CliRunner()
+    cli_arguments = [missing_test_id_xml, project_id, test_cycle, '--pprint-on-fail']
+
+    # Expectations
+    error_msg_exp = '---DEBUG XML PRETTY PRINT---'
+
+    # Mock
+    mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
+    mocker.patch('swagger_client.TestlogApi.submit_automation_test_logs_0', return_value=mock_queue_resp)
+
+    # Test
+    result = runner.invoke(cli.main, args=cli_arguments, env=env_vars)
+    assert 1 == result.exit_code
+    assert error_msg_exp in result.output
     assert 'Failed!' in result.output

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -103,6 +103,19 @@ class TestLoadingInputJunitXMLFile(object):
         with pytest.raises(RuntimeError):
             zigzag._load_input_file(flat_all_passing_xml)
 
+    def test_schema_violation_with_pprint_on_fail(self, missing_test_id_xml):
+        """Verify that JUnitXML that violates the schema with 'pprint_on_fail' enabled with emit an error message with
+        the XML pretty printed in the error message."""
+
+        # Expectations
+        error_msg_exp = '---DEBUG XML PRETTY PRINT---'
+
+        # Test
+        try:
+            zigzag._load_input_file(missing_test_id_xml, pprint_on_fail=True)
+        except RuntimeError as e:
+            assert error_msg_exp in str(e)
+
 
 # noinspection PyUnresolvedReferences
 class TestGenerateTestLogs(object):

--- a/zigzag/cli.py
+++ b/zigzag/cli.py
@@ -15,10 +15,14 @@ import zigzag.zigzag as zz
 # Main
 # ======================================================================================================================
 @click.command()
+@click.option('--pprint-on-fail', '-p',
+              is_flag=True,
+              default=False,
+              help='Pretty print XML on schema violations to stdout')
 @click.argument('junit_input_file', type=click.Path(exists=True))
 @click.argument('qtest_project_id', type=click.INT)
 @click.argument('qtest_test_cycle', type=click.STRING)
-def main(junit_input_file, qtest_project_id, qtest_test_cycle):
+def main(junit_input_file, qtest_project_id, qtest_test_cycle, pprint_on_fail):
     """Upload JUnitXML results to qTest manager.
 
     \b
@@ -26,7 +30,6 @@ def main(junit_input_file, qtest_project_id, qtest_test_cycle):
         JUNIT_INPUT_FILE        A valid JUnit XML results file.
         QTEST_PROJECT_ID        The the target qTest Project ID for results
         QTEST_TEST_CYCLE        The qTest cycle to use as a parent for results
-
     \b
     Required Environment Variables:
         QTEST_API_TOKEN         The qTest API token to use for authorization
@@ -42,7 +45,8 @@ def main(junit_input_file, qtest_project_id, qtest_test_cycle):
         job_id = zz.upload_test_results(junit_input_file,
                                         os.environ[api_token_env_var],
                                         qtest_project_id,
-                                        qtest_test_cycle)
+                                        qtest_test_cycle,
+                                        pprint_on_fail)
 
         click.echo(click.style("\nQueue Job ID: {}".format(str(job_id))))
         click.echo(click.style("\nSuccess!", fg='green'))


### PR DESCRIPTION
With this new command-line option enabled a debug print-out of the JUnitXML
file will be displayed on screen when a schema violation occurs.