### PR TITLE
ASC-455 Fix for Test Name Missing from Failure Message

### DIFF
--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -127,6 +127,14 @@ def _generate_test_logs(junit_xml):
         test_log = swagger_client.AutomationTestLogResource()
 
         try:
+            test_log.name = TESTCASE_NAME_RGX.match(testcase_xml.attrib['name']).group(1)
+            test_log.automation_content = testcase_xml.find("./properties/property/[@name='test_id']").attrib['value']
+            test_log.exe_start_date = testcase_xml.find("./properties/property/[@name='start_time']").attrib['value']
+            test_log.exe_end_date = testcase_xml.find("./properties/property/[@name='end_time']").attrib['value']
+        except AttributeError:
+            raise RuntimeError("Test case '{}' is missing the required property!".format(test_log.name))
+
+        try:
             test_log.build_url = testsuite_props['BUILD_URL']
             test_log.build_number = testsuite_props['BUILD_NUMBER']
             test_log.module_names = _generate_module_hierarchy(testcase_xml, testsuite_props)
@@ -134,14 +142,6 @@ def _generate_test_logs(junit_xml):
             raise RuntimeError("Test suite is missing the required property!\n\n{}".format(str(e)))
         except AttributeError:
             raise RuntimeError("Test case '{}' has an invalid 'classname' attribute!".format(test_log.name))
-
-        try:
-            test_log.name = TESTCASE_NAME_RGX.match(testcase_xml.attrib['name']).group(1)
-            test_log.automation_content = testcase_xml.find("./properties/property/[@name='test_id']").attrib['value']
-            test_log.exe_start_date = testcase_xml.find("./properties/property/[@name='start_time']").attrib['value']
-            test_log.exe_end_date = testcase_xml.find("./properties/property/[@name='end_time']").attrib['value']
-        except AttributeError:
-            raise RuntimeError("Test case '{}' is missing the required property!".format(test_log.name))
 
         test_log.status = testcase_status
         test_log.attachments = \


### PR DESCRIPTION
Changed the order of the collection of test log properties so that the test
name will always be captured in failure messages.