### PR TITLE
ASC-456 Fix to Allow Dashes in "py.test" Filenames

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,6 +409,30 @@ def missing_build_url_xml(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
+def classname_with_dashes_xml(tmpdir_factory):
+    """JUnitXML sample representing a testcase that has a 'classname' attribute which contains dashes for the py.test
+    filename."""
+
+    filename = tmpdir_factory.mktemp('data').join('classname_with_dashes.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="test.tests.test_for_acs-150.TestForRPC10PlusPostDeploymentQCProcess"
+            file="tests/test_for_acs-150.py" line="140"
+            name="test_verify_kibana_horizon_access_with_no_ssh[_testinfra_host0]" time="0.00372695922852">
+                {testcase_properties}
+            </testcase>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
 def invalid_classname_xml(tmpdir_factory):
     """JUnitXML sample representing a testcase that has an invalid 'classname' attribute which is used to build the
     results hierarchy in the '_generate_module_hierarchy' function."""

--- a/tests/test_zigzag.py
+++ b/tests/test_zigzag.py
@@ -242,6 +242,32 @@ class TestGenerateTestLogs(object):
         assert attachment_exp_content_type == test_log_dict['attachments'][0]['content_type']
         assert attachment_exp_data_md5 == md5(test_log_dict['attachments'][0]['data'].encode('UTF-8')).hexdigest()
 
+    def test_classname_containing_dashes(self, classname_with_dashes_xml):
+        """Verify that JUnitXML that has a 'classname' containing dashes (captured from the py.test filename) is
+        validated correctly.
+        """
+
+        # Setup
+        junit_xml = zigzag._load_input_file(classname_with_dashes_xml)
+        # noinspection PyUnresolvedReferences
+        test_log_dict = zigzag._generate_test_logs(junit_xml)[0].to_dict()
+
+        # Expectation
+        test_name = 'test_verify_kibana_horizon_access_with_no_ssh'
+        module_names = ['RPC_RELEASE',
+                        'JOB_NAME',
+                        'MOLECULE_TEST_REPO',
+                        'MOLECULE_SCENARIO_NAME',
+                        'test_for_acs-150',
+                        'TestForRPC10PlusPostDeploymentQCProcess']
+        test_log_exp = pytest.helpers.merge_dicts(SHARED_TEST_LOG_EXP, {'name': test_name,
+                                                                        'status': 'PASSED',
+                                                                        'module_names': module_names})
+
+        # Test
+        for exp in test_log_exp:
+            assert test_log_exp[exp] == test_log_dict[exp]
+
     def test_invalid_classname(self, invalid_classname_xml):
         """Verify that JUnitXML that has an invalid 'classname' attribute for a testcase raises a RuntimeError."""
 

--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -17,7 +17,7 @@ from swagger_client.rest import ApiException
 # Globals
 # ======================================================================================================================
 TESTCASE_NAME_RGX = re.compile(r'(\w+)(\[.+\])')
-TESTCASE_GROUP_RGX = re.compile(r'tests\.(test_\w+)\.?(Test\w+)?$')
+TESTCASE_GROUP_RGX = re.compile(r'tests\.(test_[\w-]+)\.?(Test\w+)?$')
 MAX_FILE_SIZE = 52428800
 
 


### PR DESCRIPTION
Loosen the regex for the "classname" attribute to allow for dashes in the
"py.test" filename.