### PR TITLE
Release v0.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.8.0
 commit = false
 tag = false
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ entry_points = {
 
 setup(
     name='rpc-zigzag',
-    version='0.7.1',
+    version='0.8.0',
     author="rcbops",
     author_email='rcb-deploy@lists.rackspace.com',
     maintainer='rcbops',

--- a/zigzag/__init__.py
+++ b/zigzag/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """rcbops"""
 __email__ = 'rcb-deploy@lists.rackspace.com'
-__version__ = '0.7.1'
+__version__ = '0.8.0'


### PR DESCRIPTION
This release adds support for pretty printing XML output on schema failures
to allow for debugging issues using CI logs.

Bug fixes:

 - ASC-455 Fix for Test Name Missing from Failure Message
 - ASC-456 Fix to Allow Dashes in "py.test" Filenames