### PR TITLE
ASC-437 Auto-discover Test Cycle Parent

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,3 @@ replace = __version__ = '{new_version}'
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = docs
-
-[tool:pytest]
-collect_ignore = ['setup.py']
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
+import swagger_client
 from zigzag import cli
 from click.testing import CliRunner
 
@@ -15,17 +16,22 @@ def test_cli_happy_path(single_passing_xml, mocker):
     # Setup
     env_vars = {'QTEST_API_TOKEN': 'valid_token'}
     project_id = '12345'
-    test_cycle = 'CL-1'
+    test_cycle_name = 'RPC_PRODUCT_RELEASE'
+    test_cycle_pid = 'CL-1'
 
     runner = CliRunner()
-    cli_arguments = [single_passing_xml, project_id, test_cycle]
+    cli_arguments = [single_passing_xml, project_id]
 
     # Expectation
     job_id = '54321'
 
     # Mock
     mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
+    mock_tc_resp = mocker.Mock(spec=swagger_client.TestCycleResource)
+    mock_tc_resp.to_dict.return_value = {'name': test_cycle_name, 'pid': test_cycle_pid}
+
     mocker.patch('swagger_client.TestlogApi.submit_automation_test_logs_0', return_value=mock_queue_resp)
+    mocker.patch('swagger_client.TestcycleApi.get_test_cycles', return_value=[mock_tc_resp])
 
     # Test
     result = runner.invoke(cli.main, args=cli_arguments, env=env_vars)
@@ -39,10 +45,11 @@ def test_cli_missing_api_token(single_passing_xml, mocker):
 
     # Setup
     project_id = '12345'
-    test_cycle = 'CL-1'
+    test_cycle_name = 'RPC_PRODUCT_RELEASE'
+    test_cycle_pid = 'CL-1'
 
     runner = CliRunner()
-    cli_arguments = [single_passing_xml, project_id, test_cycle]
+    cli_arguments = [single_passing_xml, project_id]
 
     # Expectation
     job_id = '54321'
@@ -50,7 +57,11 @@ def test_cli_missing_api_token(single_passing_xml, mocker):
 
     # Mock
     mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
+    mock_tc_resp = mocker.Mock(spec=swagger_client.TestCycleResource)
+    mock_tc_resp.to_dict.return_value = {'name': test_cycle_name, 'pid': test_cycle_pid}
+
     mocker.patch('swagger_client.TestlogApi.submit_automation_test_logs_0', return_value=mock_queue_resp)
+    mocker.patch('swagger_client.TestcycleApi.get_test_cycles', return_value=[mock_tc_resp])
 
     # Test
     result = runner.invoke(cli.main, args=cli_arguments)
@@ -59,24 +70,55 @@ def test_cli_missing_api_token(single_passing_xml, mocker):
     assert 'Failed!' in result.output
 
 
+def test_specify_test_cycle(single_passing_xml, mocker):
+    """Verify that the CLI will allow the user to set the '--pprint-on-fail' flag for debug printing."""
+
+    # Setup
+    env_vars = {'QTEST_API_TOKEN': 'valid_token'}
+    project_id = '12345'
+    test_cycle_pid = 'CL-1'
+
+    runner = CliRunner()
+    cli_arguments = [single_passing_xml, project_id, '--qtest-test-cycle={}'.format(test_cycle_pid)]
+
+    # Expectation
+    job_id = '54321'
+
+    # Mock
+    mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
+
+    mocker.patch('swagger_client.TestlogApi.submit_automation_test_logs_0', return_value=mock_queue_resp)
+
+    # Test
+    result = runner.invoke(cli.main, args=cli_arguments, env=env_vars)
+    assert 0 == result.exit_code
+    assert 'Queue Job ID: {}'.format(job_id) in result.output
+    assert 'Success!' in result.output
+
+
 def test_cli_pprint_on_fail(missing_test_id_xml, mocker):
     """Verify that the CLI will allow the user to set the '--pprint-on-fail' flag for debug printing."""
 
     # Setup
     env_vars = {'QTEST_API_TOKEN': 'valid_token'}
     project_id = '12345'
-    test_cycle = 'CL-1'
     job_id = '54321'
+    test_cycle_name = 'RPC_PRODUCT_RELEASE'
+    test_cycle_pid = 'CL-1'
 
     runner = CliRunner()
-    cli_arguments = [missing_test_id_xml, project_id, test_cycle, '--pprint-on-fail']
+    cli_arguments = [missing_test_id_xml, project_id, '--pprint-on-fail']
 
     # Expectations
     error_msg_exp = '---DEBUG XML PRETTY PRINT---'
 
     # Mock
     mock_queue_resp = mocker.Mock(state='IN_WAITING', id=job_id)
+    mock_tc_resp = mocker.Mock(spec=swagger_client.TestCycleResource)
+    mock_tc_resp.to_dict.return_value = {'name': test_cycle_name, 'pid': test_cycle_pid}
+
     mocker.patch('swagger_client.TestlogApi.submit_automation_test_logs_0', return_value=mock_queue_resp)
+    mocker.patch('swagger_client.TestcycleApi.get_test_cycles', return_value=[mock_tc_resp])
 
     # Test
     result = runner.invoke(cli.main, args=cli_arguments, env=env_vars)

--- a/zigzag/cli.py
+++ b/zigzag/cli.py
@@ -19,9 +19,12 @@ import zigzag.zigzag as zz
               is_flag=True,
               default=False,
               help='Pretty print XML on schema violations to stdout')
+@click.option('--qtest-test-cycle', '-t',
+              type=click.STRING,
+              default=None,
+              help='Specify a test cycle to use as a parent for results.')
 @click.argument('junit_input_file', type=click.Path(exists=True))
 @click.argument('qtest_project_id', type=click.INT)
-@click.argument('qtest_test_cycle', type=click.STRING)
 def main(junit_input_file, qtest_project_id, qtest_test_cycle, pprint_on_fail):
     """Upload JUnitXML results to qTest manager.
 
@@ -29,7 +32,6 @@ def main(junit_input_file, qtest_project_id, qtest_test_cycle, pprint_on_fail):
     Required Arguments:
         JUNIT_INPUT_FILE        A valid JUnit XML results file.
         QTEST_PROJECT_ID        The the target qTest Project ID for results
-        QTEST_TEST_CYCLE        The qTest cycle to use as a parent for results
     \b
     Required Environment Variables:
         QTEST_API_TOKEN         The qTest API token to use for authorization


### PR DESCRIPTION
In order to make zigzag more flexible to reduce changes to CI jobs the
automatic discovery of the root test cycles parent has been implemented.
The cmdline interface was updated to change the required test cycle argument
into an option.