### PR TITLE
ASC-761 add a failure log summary

### DIFF
--- a/tests/unit/test_zigzag.py
+++ b/tests/unit/test_zigzag.py
@@ -310,7 +310,8 @@ class TestParseXMLtoTestLogs(object):
 
         assert 'test_error' == test_log.name
         assert 'FAILED' == test_log.status
-        assert 'def error_fixture(host):' in test_log.failure_output
+        assert 'def error_fixture(host):' in test_log.failure_output \
+            or 'log truncated. Please see attached log file.' in test_log.failure_output
         assert '2018-04-10T21:38:18Z' == test_log.start_date
         assert '2018-04-10T21:38:19Z' == test_log.end_date
         assert ['ASC-123', 'ASC-456'] == test_log.jira_issues

--- a/tests/unit/test_zigzag_test_log.py
+++ b/tests/unit/test_zigzag_test_log.py
@@ -260,3 +260,42 @@ class TestZigZagTestLog(object):
         assert isinstance(tl.qtest_test_log.attachments, list)
         assert len(tl.qtest_test_log.attachments) == 1
         assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+    def test_log_truncation(self, single_fail_xml, mocker):
+        """Test to ensure that log messages are truncated correctly"""
+        qtest_id = 123456789
+        search_response = {
+            "links": [],
+            "page": 1,
+            "page_size": 100,
+            "total": 1,
+            "items": [
+                {
+                    "id": qtest_id,
+                    "name": "PRO-18405 Fake!"
+                }
+            ]
+        }
+
+        # a mock for a ZigZag object
+        zz = mocker.MagicMock()
+        zz._qtest_api_token = 'totally real'
+        zz._qtest_project_id = '54321'
+
+        # patch the API calls
+        mock_post_response = mocker.Mock(spec=requests.Response)
+        mock_post_response.text = json.dumps(search_response)
+        mocker.patch('requests.post', return_value=mock_post_response)
+        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
+        mock_field_resp.id = 12345
+        mock_field_resp.label = 'Failure Output'
+        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
+
+        # create a new TestLog object with fixture xml and the zz object
+        junit_xml_doc = etree.parse(single_fail_xml)
+        test_case_xml = junit_xml_doc.find('testcase')
+        tl = ZigZagTestLog(test_case_xml, zz)
+        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
+
+        assert len(tl._failure_output) == \
+            len(tl._max_log_message_length_notification) + tl._max_log_message_length

--- a/zigzag/zigzag_test_log.py
+++ b/zigzag/zigzag_test_log.py
@@ -31,6 +31,9 @@ class ZigZagTestLog(object):
             mediator (ZigZag): the mediator that stores shared data
         """
 
+        self._max_log_message_length = 100
+        self._max_log_message_length_notification = "... log truncated. Please see attached log file."
+
         self._exe_end_date = None
         self._exe_start_date = None
 
@@ -272,11 +275,16 @@ class ZigZagTestLog(object):
             self._status = 'FAILED'
 
             if self.test_run_failure_output_field_id is not None:
+                max_log_message_length = self._max_log_message_length
                 errors = self._testcase_xml.findall('error')
                 failures = self._testcase_xml.findall('failure')
                 possible_messages = errors + failures
                 message = "\n".join([element.text for element in possible_messages if element is not None])
-                self._failure_output = message
+                if len(message) > max_log_message_length:
+                    self._failure_output = message[:max_log_message_length] + \
+                        self._max_log_message_length_notification
+                else:
+                    self._failure_output = message
 
         elif self._testcase_xml.find('skipped') is not None:
             self._status = 'SKIPPED'


### PR DESCRIPTION
Prior to this change a very long log output string could be
put in the qtest failure output field. This can throw off the
page layout.

This update truncates the log if it's over some character limit
and refers the user to the attached text file containing the
log output.