### PR TITLE
ASC-864 Fix Crash on Failure Attachment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ test: check-unit ## run unit tests quickly with the default Python
 test-integration: check-integration ## run integration tests with the default Python
 	py.test tests/integration
 
-test-all: ## run unit tests on every Python version with tox
-	tox
+test-all: ## run lint, unit and integration tests on all supported Python versions
+	tox -epy27,py35,flake8,integration_py27,integration_py35,integration_py36
 
 coverage-html: ## check code coverage with an HTML report
 	py.test --cov-report html --cov=zigzag tests/
@@ -123,14 +123,14 @@ bump-minor: ## bumps the version of by minor
 bump-patch: ## bumps the version of by patch
 	bumpversion patch
 
-release-major: clean-build build develop bump-major lint test publish ## package and upload a major release
+release-major: develop lint test-all bump-major build publish ## package and upload a major release
 	echo 'Successfully released!'
 	echo 'Please push the newly created tag and commit to GitHub.'
 
-release-minor: clean-build build develop bump-minor lint test publish ## package and upload a minor release
+release-minor: develop lint test-all bump-minor build publish ## package and upload a minor release
 	echo 'Successfully released!'
 	echo 'Please push the newly created tag and commit to GitHub.'
 
-release-patch: clean-build build develop bump-patch lint test publish ## package and upload a patch release
+release-patch: develop lint test-all bump-patch build publish ## package and upload a patch release
 	echo 'Successfully released!'
 	echo 'Please push the newly created tag and commit to GitHub.'

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -4,26 +4,31 @@ Release Process
 
 The easiest way to release a new version of zigzag is to use make.
 
-1. First you will need to know the username and password for the account you want to use to release to PyPI shared_accounts_
+1. First you will need to know the username and password for the account you want to use to release to PyPI by referring to the ASC `shared accounts`_ page.
 
 2. You will need to make sure that you are on the master branch, your working directory is clean and up to date.
 
 3. Decide if you are going to increment the major, minor, or patch version.  You can refer to semver_ to help you make that decision.
 
-4. Use the `release-major`, `release-minor`, or `release-patch`.
+4. Verify that the pre-requisites for running `integration tests`_ are satisfied. (See the "Executing Integration Tests" section)
 
-**make release** ::
+5. Use the `release-major`, `release-minor`, or `release-patch`.
 
-    make release-minor
-5. The task will stop and prompt you for you PyPI username and password if you dont have these set in your `.pypirc` file.
+    **make release** ::
 
-6. Once the task has successfully completed you need to push the tag and commit.
+        make release-minor
 
-**push tag** ::
+6. The task will stop and prompt you for you PyPI username and password if you don't have these set in your `.pypirc` file.
 
-    git push origin && git push origin refs/tags/<tagname>
-7. Create a release on GitHub. GitHub_release_
+7. Once the task has successfully completed you need to push the tag and commit.
 
+    **push tag** ::
+
+        git push origin && git push origin refs/tags/<tagname>
+
+8. Create a `GitHub release`_.
+
+.. _integration tests: integration_testing.rst
 .. _semver: https://semver.org
-.. _shared_accounts: https://rpc-openstack.atlassian.net/wiki/spaces/ASC/pages/143949893/Useful+Links#UsefulLinks-SharedAccounts
-.. _GitHub_release: https://help.github.com/articles/creating-releases/
+.. _shared accounts: https://rpc-openstack.atlassian.net/wiki/spaces/ASC/pages/143949893/Useful+Links#UsefulLinks-SharedAccounts
+.. _GitHub release: https://help.github.com/articles/creating-releases/

--- a/tests/data/junit.xml.j2
+++ b/tests/data/junit.xml.j2
@@ -7,7 +7,7 @@ skips="{{ tests.skip_count }}"
 tests="{{ tests.total_count }}"
 time="{{ tests.total_duration }}">
     <properties>
-    {% for key, value in global_props.iteritems() %}
+    {% for key, value in global_props.items() %}
         <property name="{{ key }}" value="{{ value }}"/>
     {% endfor %}
     </properties>

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1270,7 +1270,7 @@ class ZigZagRunner(object):
             self.clean_up()
         self.tests.reset()  # This is for super safety in case a developer was being tricky with execution
 
-        with open(self._junit_xml_file_path, 'wb') as f:
+        with open(self._junit_xml_file_path, 'w') as f:
             f.write(self._junit_template.render(tests=self._tests, global_props=self._global_props))
 
         zz = ZigZag(self._junit_xml_file_path,

--- a/tests/integration/test_negative.py
+++ b/tests/integration/test_negative.py
@@ -7,7 +7,7 @@
 # ======================================================================================================================
 import pytest
 import swagger_client
-from conftest import ZigZagRunner
+from .conftest import ZigZagRunner
 
 
 # ======================================================================================================================
@@ -85,7 +85,7 @@ class TestNegativeScenarios(object):
         with pytest.raises(RuntimeError) as e:
             neg_invalid_api_token.assert_invoke_zigzag()
 
-        assert 'Reason: Unauthorized' in e.value.message
+        assert 'Reason: Unauthorized' in str(e.value)
 
     # noinspection PyShadowingNames
     def test_invalid_project_id(self, neg_invalid_project_id):
@@ -95,5 +95,5 @@ class TestNegativeScenarios(object):
         with pytest.raises(RuntimeError) as e:
             neg_invalid_project_id.assert_invoke_zigzag()
 
-        assert 'Status code: 404' in e.value.message
-        assert 'Reason: Not Found' in e.value.message
+        assert 'Status code: 404' in str(e.value)
+        assert 'Reason: Not Found' in str(e.value)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,54 @@ commands =
     pip install -U pip
     py.test --basetemp={envtmpdir} tests/unit
 
+[testenv:integration_py27]
+basepython = python2.7
+passenv = QTEST_*
+whitelist_externals = make
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following line:
+;     -r{toxinidir}/requirements.txt
+commands =
+    pip install -U pip
+    make check-integration
+    py.test --basetemp={envtmpdir} tests/integration
+
+[testenv:integration_py35]
+basepython = python3.5
+passenv = QTEST_*
+whitelist_externals = make
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following line:
+;     -r{toxinidir}/requirements.txt
+commands =
+    pip install -U pip
+    make check-integration
+    py.test --basetemp={envtmpdir} tests/integration
+
+[testenv:integration_py36]
+basepython = python3.6
+passenv = QTEST_*
+whitelist_externals = make
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following line:
+;     -r{toxinidir}/requirements.txt
+commands =
+    pip install -U pip
+    make check-integration
+    py.test --basetemp={envtmpdir} tests/integration
+
 [flake8]
 max-line-length = 120
 basepython = python
@@ -22,3 +70,4 @@ deps = flake8
 
 [testenv:flake8]
 commands = flake8 zigzag setup.py tests
+

--- a/zigzag/zigzag_test_log.py
+++ b/zigzag/zigzag_test_log.py
@@ -3,7 +3,6 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
-
 from __future__ import absolute_import
 import swagger_client
 from base64 import b64encode
@@ -230,7 +229,8 @@ class ZigZagTestLog(object):
             log.attachments.append(
                 swagger_client.AttachmentResource(name="failure_output_{}.txt".format(log.attachment_suffix),
                                                   content_type='text/plain',
-                                                  data=b64encode(log.full_fail_log_text.encode('UTF-8')),
+                                                  data=b64encode(
+                                                      log.full_fail_log_text.encode('UTF-8')).decode('UTF-8'),
                                                   author={}))
         return log
 


### PR DESCRIPTION
Turns out that running ZigZag under Python 3.x breaks everything. :(
This commit fixes the underlying issue while also updating the integration test
suite for Python 3.x compatibility. Furthermore, the Makefile and release
process documentation have been updated to ensure that all tests are ran before
release.