### PR TITLE
ASC-867 Improve Failure Output Truncation

### DIFF
--- a/tests/integration/test_failure_output.py
+++ b/tests/integration/test_failure_output.py
@@ -266,11 +266,13 @@ class TestFailureOutputField(object):
         test_runs = multi_line_failure_message_for_asc.tests[0].qtest_test_runs
 
         # Expectations
-        test_failure_msg_regex_exp = r"E       assert 'Ubuntu 14\.04 LTS' in ''"
+        test_failure_msg_exp = """Log truncated, please see attached failure log for more details...
+E       assert 'Ubuntu 14.04 LTS' in ''
+E        +  where '' = CommandResult(command="lxc-attach -n `lxc-ls -1 | grep utility | head -n 1` --...ls is deprecated..."""     # noqa
 
         # Test
         assert len(test_runs) == 1
-        pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)
+        pytest.helpers.assert_qtest_property(test_runs[0], 'Failure Output', test_failure_msg_exp)
 
     # noinspection PyUnresolvedReferences
     def test_truncated_failure_output_for_mk8s(self, multi_line_failure_message_for_mk8s):
@@ -283,8 +285,10 @@ class TestFailureOutputField(object):
         test_runs = multi_line_failure_message_for_mk8s.tests[0].qtest_test_runs
 
         # Expectations
-        test_failure_msg_regex_exp = r"E       docker\.errors\.APIError: 500 Server Error"
+        test_failure_msg_exp = """Log truncated, please see attached failure log for more details...
+>       raise cls(e, response=response, explanation=explanation)
+E       docker.errors.APIError: 500 Server Error: Internal Server Error ("Get https://registry.kubernetes-mk8s-t-inst-pr..."""  # noqa
 
         # Test
         assert len(test_runs) == 1
-        pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)
+        pytest.helpers.assert_qtest_property(test_runs[0], 'Failure Output', test_failure_msg_exp)

--- a/tests/integration/test_failure_output.py
+++ b/tests/integration/test_failure_output.py
@@ -9,6 +9,159 @@ import pytest
 
 
 # ======================================================================================================================
+# Fixtures
+# ======================================================================================================================
+# noinspection PyShadowingNames
+@pytest.fixture
+def multi_line_failure_message_for_asc(_zigzag_runner_factory):
+    """ZigZag CLI runner configured for the "asc" CI environment with one failing test that has a multi-line failure
+    message which will need to be truncated.
+
+    Returns:
+        ZigZagRunner
+    """
+
+    failure_message = '''host = &lt;testinfra.host.Host object at 0x7fa5a7fda3d0&gt;
+
+    @pytest.mark.test_id('d7fc612b-432a-11e8-9a7a-6a00035510c0')
+    @pytest.mark.jira('asc-240')
+    def test_verify_glance_image(host):
+        """Verify the glance images created by:
+        https://github.com/openstack/openstack-ansible-ops/blob/master/multi-node-aio/playbooks/vars/openstack-service-config.yml
+        """
+        cmd = attach_utility_container + "'. /root/openrc ; openstack image list'"
+        output = host.run(cmd)
+&gt;       assert ("Ubuntu 14.04 LTS" in output.stdout)
+E       assert 'Ubuntu 14.04 LTS' in ''
+E        +  where '' = CommandResult(command="lxc-attach -n `lxc-ls -1 | grep utility | head -n 1` --...ls is deprecated and will be removed after Jun 2017. Please use osc_lib.utils').stdout
+
+tests/test_scan_images_and_flavors.py:26: AssertionError'''     # noqa
+
+    zz_runner = _zigzag_runner_factory('multi_line_failure_message_for_asc.xml', 'asc')
+    zz_runner.add_test_case('failure', message=failure_message)
+
+    return zz_runner
+
+
+# noinspection PyShadowingNames
+@pytest.fixture
+def multi_line_failure_message_for_mk8s(_zigzag_runner_factory):
+    """ZigZag CLI runner configured for the "asc" CI environment with one failing test that has a multi-line failure
+    message which will need to be truncated.
+
+    Returns:
+        ZigZagRunner
+    """
+
+    failure_message = '''self = &lt;docker.api.client.APIClient object at 0x7f3047082080&gt;
+response = &lt;Response [500]&gt;
+
+    def _raise_for_status(self, response):
+        """Raises stored :class:`APIError`, if one occurred."""
+        try:
+&gt;           response.raise_for_status()
+
+/usr/local/lib/python3.5/dist-packages/docker/api/client.py:225: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = &lt;Response [500]&gt;
+
+    def raise_for_status(self):
+        """Raises stored :class:`HTTPError`, if one occurred."""
+
+        http_error_msg = ''
+        if isinstance(self.reason, bytes):
+            # We attempt to decode utf-8 first because some servers
+            # choose to localize their reason strings. If the string
+            # isn't utf-8, we fall back to iso-8859-1 for all other
+            # encodings. (See PR #3538)
+            try:
+                reason = self.reason.decode('utf-8')
+            except UnicodeDecodeError:
+                reason = self.reason.decode('iso-8859-1')
+        else:
+            reason = self.reason
+
+        if 400 &lt;= self.status_code &lt; 500:
+            http_error_msg = u'%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
+
+        elif 500 &lt;= self.status_code &lt; 600:
+            http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
+
+        if http_error_msg:
+&gt;           raise HTTPError(http_error_msg, response=self)
+E           requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/v1.35/auth
+
+/usr/local/lib/python3.5/dist-packages/requests/models.py:935: HTTPError
+
+During handling of the above exception, another exception occurred:
+
+authtoken = 'c04b8a551535c99f2743d24a4237f46d9b9ac566c2d63906f8b06fd3a557ddc0'
+harbor_project = 'mk8s-t-inst-pr-261-27'
+
+    @pytest.mark.test_id('14d8e10a-7568-11e8-ab5e-0025227c8120')
+    @pytest.mark.jira('K8S-877')
+    @pytest.mark.parametrize('harbor_project',
+                             [(DockerRegistry.OS_USERNAME, 'authtoken')],
+                             indirect=True)
+    def test_nonadmin_push_and_delete(authtoken, harbor_project):
+        """
+         push/pull from docker registry while logging in as user
+
+        """
+        # login as user and create a project
+        user_registry = "{registry}/{project_name}/{image_name}". \
+            format(registry=DockerRegistry.REGISTRY,
+                   project_name=harbor_project,
+                   image_name=DockerRegistry.IMAGE)
+
+        # CLI login to registry as user using token
+        response = client.login(username=DockerRegistry.OS_USERNAME,
+                                password=authtoken,
+&gt;                               registry=user_registry)
+
+tests/quality_check/managedservices/test_harbor.py:66: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/usr/local/lib/python3.5/dist-packages/docker/api/daemon.py:150: in login
+    return self._result(response, json=True)
+/usr/local/lib/python3.5/dist-packages/docker/api/client.py:231: in _result
+    self._raise_for_status(response)
+/usr/local/lib/python3.5/dist-packages/docker/api/client.py:227: in _raise_for_status
+    raise create_api_error_from_http_exception(e)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+e = HTTPError('500 Server Error: Internal Server Error for url: http+docker://localhost/v1.35/auth',)
+
+    def create_api_error_from_http_exception(e):
+        """
+        Create a suitable APIError from requests.exceptions.HTTPError.
+        """
+        response = e.response
+        try:
+            explanation = response.json()['message']
+        except ValueError:
+            explanation = (response.content or '').strip()
+        cls = APIError
+        if response.status_code == 404:
+            if explanation and ('No such image' in str(explanation) or
+                                'not found: does not exist or no pull access'
+                                in str(explanation) or
+                                'repository does not exist' in str(explanation)):
+                cls = ImageNotFound
+            else:
+                cls = NotFound
+&gt;       raise cls(e, response=response, explanation=explanation)
+E       docker.errors.APIError: 500 Server Error: Internal Server Error ("Get https://registry.kubernetes-mk8s-t-inst-pr-261-27.mk8s-t-inst-pr-261-27.mk8s.systems/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)")
+
+/usr/local/lib/python3.5/dist-packages/docker/errors.py:31: APIError'''     # noqa
+
+    zz_runner = _zigzag_runner_factory('multi_line_failure_message_for_mk8s.xml', 'mk8s')
+    zz_runner.add_test_case('failure', message=failure_message)
+
+    return zz_runner
+
+
+# ======================================================================================================================
 # Test Suites
 # ======================================================================================================================
 class TestFailureOutputField(object):
@@ -101,3 +254,37 @@ class TestFailureOutputField(object):
         # Test
         assert len(test_runs) == 1
         pytest.helpers.assert_qtest_property(test_runs[0], 'Failure Output', '')
+
+    # noinspection PyUnresolvedReferences
+    def test_truncated_failure_output_for_asc(self, multi_line_failure_message_for_asc):
+        """Verify the qTest 'Failure Output' test log field is populated with the correct message for a single test
+        failing from the "asc" CI environment.
+        """
+
+        # Setup
+        multi_line_failure_message_for_asc.assert_invoke_zigzag()
+        test_runs = multi_line_failure_message_for_asc.tests[0].qtest_test_runs
+
+        # Expectations
+        test_failure_msg_regex_exp = r"E       assert 'Ubuntu 14\.04 LTS' in ''"
+
+        # Test
+        assert len(test_runs) == 1
+        pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)
+
+    # noinspection PyUnresolvedReferences
+    def test_truncated_failure_output_for_mk8s(self, multi_line_failure_message_for_mk8s):
+        """Verify the qTest 'Failure Output' test log field is populated with the correct message for a single test
+        failing from the "asc" CI environment.
+        """
+
+        # Setup
+        multi_line_failure_message_for_mk8s.assert_invoke_zigzag()
+        test_runs = multi_line_failure_message_for_mk8s.tests[0].qtest_test_runs
+
+        # Expectations
+        test_failure_msg_regex_exp = r"E       docker\.errors\.APIError: 500 Server Error"
+
+        # Test
+        assert len(test_runs) == 1
+        pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)

--- a/tests/unit/test_zigzag_test_log.py
+++ b/tests/unit/test_zigzag_test_log.py
@@ -3,26 +3,113 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
-import swagger_client
-from zigzag.zigzag_test_log import ZigZagTestLog
-import requests
 import json
+import pytest
+import requests
+import swagger_client
 from lxml import etree
+from zigzag.zigzag_test_log import ZigZagTestLog
+from .conftest import DEFAULT_GLOBAL_PROPERTIES, DEFAULT_TESTCASE_PROPERTIES
 
 
 # ======================================================================================================================
 # Globals
 # ======================================================================================================================
-
-# Shared variables
 TOKEN = 'VALID_TOKEN'
 PROJECT_ID = 12345
 TEST_CYCLE = 'CL-1'
+LONG_FAILURE_MESSAGE = ('This is a very long failure message produced by a test fixture in order to validate that the '
+                        'failure output truncation works as intended because clowns!')
+
+
+# ======================================================================================================================
+# Fixtures
+# ======================================================================================================================
+@pytest.fixture
+def short_single_line_failure_message(tmpdir_factory):
+    """Failing test case with a short single line failure message."""
+
+    filename = tmpdir_factory.mktemp('data').join('short_single_line_failure_message.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="short">Short</failure>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES, testcase_properties=DEFAULT_TESTCASE_PROPERTIES)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture
+def long_single_line_failure_message(tmpdir_factory):
+    """Failing test case with a long (153 characters) single line failure message."""
+
+    filename = tmpdir_factory.mktemp('data').join('long_single_line_failure_message.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="long">{failure_message}</failure>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES,
+                   testcase_properties=DEFAULT_TESTCASE_PROPERTIES,
+                   failure_message=LONG_FAILURE_MESSAGE)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture
+def long_multi_line_failure_message(tmpdir_factory):
+    """Failing test case with 7 long (153 characters) lines in failure message."""
+
+    filename = tmpdir_factory.mktemp('data').join('long_multi_line_failure_message.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="very long">
+                    {failure_message}
+                    {failure_message}
+                    {failure_message}
+                    {failure_message}
+                    {failure_message}
+                    {failure_message}
+                    {failure_message}
+                </failure>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=DEFAULT_GLOBAL_PROPERTIES,
+                   testcase_properties=DEFAULT_TESTCASE_PROPERTIES,
+                   failure_message=LONG_FAILURE_MESSAGE)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
 
 
 # ======================================================================================================================
 # Test Suites
 # ======================================================================================================================
+# noinspection PyProtectedMember
 class TestZigZagTestLog(object):
     """Tests for the TestLog class"""
 
@@ -171,52 +258,6 @@ class TestZigZagTestLog(object):
         # there should be two requirements since xml has two jira marks
         assert tl.qtest_requirements == [qtest_id, qtest_id]
 
-    def test_failed_test_case_attachments(self, single_fail_xml, mocker):
-        """Test to ensure that test artifacts are being correctly attached
-        Ensure that there are two attachments, one of type xml and one of type
-        text.
-        """
-        qtest_id = 123456789
-        search_response = {
-            "links": [],
-            "page": 1,
-            "page_size": 100,
-            "total": 1,
-            "items": [
-                {
-                    "id": qtest_id,
-                    "name": "PRO-18405 Fake!"
-                }
-            ]
-        }
-
-        # a mock for a ZigZag object
-        zz = mocker.MagicMock()
-        zz._qtest_api_token = 'totally real'
-        zz._qtest_project_id = '54321'
-
-        # patch the API calls
-        mock_post_response = mocker.Mock(spec=requests.Response)
-        mock_post_response.text = json.dumps(search_response)
-        mocker.patch('requests.post', return_value=mock_post_response)
-        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
-        mock_field_resp.id = 12345
-        mock_field_resp.label = 'Failure Output'
-        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
-
-        # create a new TestLog object with fixture xml and the zz object
-        junit_xml_doc = etree.parse(single_fail_xml)
-        test_case_xml = junit_xml_doc.find('testcase')
-        tl = ZigZagTestLog(test_case_xml, zz)
-        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
-
-        # there should be a list of two attachments: the junit xml
-        # file and a text log
-        assert isinstance(tl.qtest_test_log.attachments, list)
-        assert len(tl.qtest_test_log.attachments) == 2
-        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
-        assert tl.qtest_test_log.attachments[1].content_type == 'text/plain'
-
     def test_successful_test_case_attachments(self, single_passing_xml, mocker):
         """Test to ensure that test artifacts are being correctly attached
         Ensure that there is only one attachment (junit.xml) in the passing case.
@@ -261,8 +302,17 @@ class TestZigZagTestLog(object):
         assert len(tl.qtest_test_log.attachments) == 1
         assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
 
-    def test_log_truncation(self, single_fail_xml, mocker):
-        """Test to ensure that log messages are truncated correctly"""
+
+# noinspection PyProtectedMember
+class TestFailedTestCases(object):
+    """Tests for failure output messagage and failure log attachment."""
+
+    def test_failed_test_case_attachments(self, single_fail_xml, mocker):
+        """Test to ensure that test artifacts are being correctly attached
+        Ensure that there are two attachments, one of type xml and one of type
+        text.
+        """
+
         qtest_id = 123456789
         search_response = {
             "links": [],
@@ -297,5 +347,167 @@ class TestZigZagTestLog(object):
         tl = ZigZagTestLog(test_case_xml, zz)
         tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
 
-        assert len(tl._failure_output) == \
-            len(tl._max_log_message_length_notification) + tl._max_log_message_length
+        # there should be a list of two attachments: the junit xml
+        # file and a text log
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 2
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+        assert tl.qtest_test_log.attachments[1].content_type == 'text/plain'
+
+    def test_truncated_failure_output(self, single_fail_xml, mocker):
+        """Test to ensure that log messages are truncated correctly"""
+
+        qtest_id = 123456789
+        search_response = {
+            "links": [],
+            "page": 1,
+            "page_size": 100,
+            "total": 1,
+            "items": [
+                {
+                    "id": qtest_id,
+                    "name": "PRO-18405 Fake!"
+                }
+            ]
+        }
+
+        # a mock for a ZigZag object
+        zz = mocker.MagicMock()
+        zz._qtest_api_token = 'totally real'
+        zz._qtest_project_id = '54321'
+
+        # patch the API calls
+        mock_post_response = mocker.Mock(spec=requests.Response)
+        mock_post_response.text = json.dumps(search_response)
+        mocker.patch('requests.post', return_value=mock_post_response)
+        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
+        mock_field_resp.id = 12345
+        mock_field_resp.label = 'Failure Output'
+        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
+
+        # create a new TestLog object with fixture xml and the zz object
+        junit_xml_doc = etree.parse(single_fail_xml)
+        test_case_xml = junit_xml_doc.find('testcase')
+        tl = ZigZagTestLog(test_case_xml, zz)
+        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
+
+        assert len(tl._failure_output.split('\n')) == 4
+
+    def test_truncated_failure_output_with_short_single_line_message(self, short_single_line_failure_message, mocker):
+        """Verify that a failure output of only one line will NOT be truncated."""
+
+        qtest_id = 123456789
+        search_response = {
+            "links": [],
+            "page": 1,
+            "page_size": 100,
+            "total": 1,
+            "items": [
+                {
+                    "id": qtest_id,
+                    "name": "PRO-18405 Fake!"
+                }
+            ]
+        }
+
+        # a mock for a ZigZag object
+        zz = mocker.MagicMock()
+        zz._qtest_api_token = 'totally real'
+        zz._qtest_project_id = '54321'
+
+        # patch the API calls
+        mock_post_response = mocker.Mock(spec=requests.Response)
+        mock_post_response.text = json.dumps(search_response)
+        mocker.patch('requests.post', return_value=mock_post_response)
+        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
+        mock_field_resp.id = 12345
+        mock_field_resp.label = 'Failure Output'
+        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
+
+        # create a new TestLog object with fixture xml and the zz object
+        junit_xml_doc = etree.parse(short_single_line_failure_message)
+        test_case_xml = junit_xml_doc.find('testcase')
+        tl = ZigZagTestLog(test_case_xml, zz)
+        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
+
+        assert tl._failure_output == 'Short'
+
+    def test_truncated_failure_output_with_long_single_line_message(self, long_single_line_failure_message, mocker):
+        """Verify that a failure output of only one line will NOT be truncated."""
+
+        qtest_id = 123456789
+        search_response = {
+            "links": [],
+            "page": 1,
+            "page_size": 100,
+            "total": 1,
+            "items": [
+                {
+                    "id": qtest_id,
+                    "name": "PRO-18405 Fake!"
+                }
+            ]
+        }
+
+        # a mock for a ZigZag object
+        zz = mocker.MagicMock()
+        zz._qtest_api_token = 'totally real'
+        zz._qtest_project_id = '54321'
+
+        # patch the API calls
+        mock_post_response = mocker.Mock(spec=requests.Response)
+        mock_post_response.text = json.dumps(search_response)
+        mocker.patch('requests.post', return_value=mock_post_response)
+        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
+        mock_field_resp.id = 12345
+        mock_field_resp.label = 'Failure Output'
+        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
+
+        # create a new TestLog object with fixture xml and the zz object
+        junit_xml_doc = etree.parse(long_single_line_failure_message)
+        test_case_xml = junit_xml_doc.find('testcase')
+        tl = ZigZagTestLog(test_case_xml, zz)
+        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
+
+        assert tl._failure_output == LONG_FAILURE_MESSAGE[:120] + '...'
+
+    def test_truncated_failure_output_with_long_multi_line_message(self, long_multi_line_failure_message, mocker):
+        """Verify that a failure output of only one line will NOT be truncated."""
+
+        qtest_id = 123456789
+        search_response = {
+            "links": [],
+            "page": 1,
+            "page_size": 100,
+            "total": 1,
+            "items": [
+                {
+                    "id": qtest_id,
+                    "name": "PRO-18405 Fake!"
+                }
+            ]
+        }
+
+        # a mock for a ZigZag object
+        zz = mocker.MagicMock()
+        zz._qtest_api_token = 'totally real'
+        zz._qtest_project_id = '54321'
+
+        # patch the API calls
+        mock_post_response = mocker.Mock(spec=requests.Response)
+        mock_post_response.text = json.dumps(search_response)
+        mocker.patch('requests.post', return_value=mock_post_response)
+        mock_field_resp = mocker.Mock(spec=swagger_client.FieldResource)
+        mock_field_resp.id = 12345
+        mock_field_resp.label = 'Failure Output'
+        mocker.patch('swagger_client.FieldApi.get_fields', return_value=[mock_field_resp])
+
+        # create a new TestLog object with fixture xml and the zz object
+        junit_xml_doc = etree.parse(long_multi_line_failure_message)
+        test_case_xml = junit_xml_doc.find('testcase')
+        tl = ZigZagTestLog(test_case_xml, zz)
+        tl._mediator.serialized_junit_xml = etree.tostring(junit_xml_doc)
+
+        assert len(tl._failure_output.split('\n')) == 4
+        assert 'Log truncated' in tl._failure_output
+        assert '{}{}'.format(LONG_FAILURE_MESSAGE[:100], '...') in tl._failure_output


### PR DESCRIPTION
In order to provide more useful failure output in the qTest interface, the
"Failure Output" field will now show truncated output from the bottom up from
the failure point.