### PR TITLE
MAINT Fix flake8 Violations

### DIFF
--- a/tests/unit/test_zigzag.py
+++ b/tests/unit/test_zigzag.py
@@ -393,7 +393,7 @@ class TestParseXMLtoTestLogs(object):
         # Test
         for log in test_logs:
             assert 'PASSED' == log.status
-            assert re.match("test_pass\d", log.name)
+            assert re.match(r'test_pass\d', log.name)
 
     def test_junit_xml_attachment(self, single_passing_xml, mocker):
         """Verify that an xml file is attached to the qTest testlog

--- a/zigzag/module_hierarchy_facade.py
+++ b/zigzag/module_hierarchy_facade.py
@@ -65,7 +65,7 @@ class ModuleHierarchyFacade(object):
             list[str]: The strings to use for the module_hierarchy
         """
 
-        pr_regex = re.compile(".*(PR-\d+).*")
+        pr_regex = re.compile(r'.*(PR-\d+).*')
         pr = re.match(pr_regex, self._mediator.testsuite_props['GIT_BRANCH'])
 
         if pr:

--- a/zigzag/zigzag_test_log.py
+++ b/zigzag/zigzag_test_log.py
@@ -424,7 +424,7 @@ class _ZigZagTestLog(object):
                                    "Status code: {}\n"
                                    "Reason: {}\n"
                                    "Message: {}".format(e.status, e.reason, e.body))
-            exact_jira_regex = re.compile('([a-zA-Z]+-\d+)')
+            exact_jira_regex = re.compile(r'([a-zA-Z]+-\d+)')
             if parsed['total'] == 1:
                 self._qtest_requirements.append(parsed['items'][0]['id'])
             elif parsed['total'] > 1:


### PR DESCRIPTION
A recent release of flake8 moved a PEP8 weak warning to strict warning which started causes flake8 violations on this project.