### PR TITLE
ASC-860 Capture 'stderr' and 'stdout' Upon Test Failure

### DIFF
--- a/tests/data/junit.xml.j2
+++ b/tests/data/junit.xml.j2
@@ -34,6 +34,8 @@ time="{{ tests.total_duration }}">
             {{ test.long_msg }}
         </{{ test.state }}>
     {% endif %}
+        <system-out>{{ test.system_out }}</system-out>
+        <system-err>{{ test.system_err }}</system-err>
     </testcase>
 {% endfor %}
 </testsuite>

--- a/tests/helper/classes/test_case_info.py
+++ b/tests/helper/classes/test_case_info.py
@@ -35,6 +35,8 @@ class TestCaseInfo(object):
                  duration=None,
                  message=None,
                  short_message=None,
+                 system_err=None,
+                 system_out=None,
                  jira_tickets=None):
         """Capture or generate test case information to be used in validation of JUnitXML documents.
 
@@ -55,6 +57,10 @@ class TestCaseInfo(object):
                 test states. (Automatically generated if value is None)
             short_message (str): The desired short message for the test which is only used for 'skipped', 'failure',
                 'error' test states. (Automatically generated if value is None)
+            system_err (str): The desired 'stderr' capture which is only used for 'error' test states.
+                (Automatically generated if value is None)
+            system_out (str): The desired 'stdout' capture which is only used for 'error' test states.
+                (Automatically generated if value is None)
             jira_tickets (list): A list of Jira ticket IDs to associated with the test case.
                 (Automatically generated if value is None)
 
@@ -75,6 +81,8 @@ class TestCaseInfo(object):
         self._duration = duration if duration else choice(range(1, 11))
         self._message = message if message else "Test execution state: {}".format(self._state)
         self._short_message = short_message if short_message else "State: {}".format(self._state)
+        self._system_err = system_err if system_err else 'stderr'
+        self._system_out = system_out if system_out else 'stdout'
         self._jira_tickets = jira_tickets if jira_tickets else ["JIRA-{}".format(choice(range(1, 100000)))]
 
         self._test_steps = []
@@ -202,7 +210,7 @@ class TestCaseInfo(object):
         """The short message for non-passed test artifact states.
 
         Returns:
-            int: Short message.
+            str
         """
 
         return self._short_message
@@ -212,10 +220,30 @@ class TestCaseInfo(object):
         """The long message for non-passed test artifact states.
 
         Returns:
-            int: Long message.
+            str
         """
 
         return self._message
+
+    @property
+    def system_err(self):
+        """The 'stderr' capture.
+
+        Returns:
+            str
+        """
+
+        return self._system_err
+
+    @property
+    def system_out(self):
+        """The 'stdout' capture.
+
+        Returns:
+            str
+        """
+
+        return self._system_out
 
     @property
     def jira_tickets(self):
@@ -643,6 +671,8 @@ class TestStepInfo(TestCaseInfo):
                  start=None,
                  duration=None,
                  message=None,
+                 system_err=None,
+                 system_out=None,
                  short_message=None):
         """Capture or generate test case information to be used in validation of JUnitXML documents.
 
@@ -656,6 +686,10 @@ class TestStepInfo(TestCaseInfo):
             duration (int): The desired duration of the test in seconds. (Automatically generated if value is None)
             message (str): The desired message for the test which is only used for 'skipped', 'failure', 'error'
                 test states. (Automatically generated if value is None)
+            system_err (str): The desired 'stderr' capture which is only used for 'error' test states.
+                (Automatically generated if value is None)
+            system_out (str): The desired 'stdout' capture which is only used for 'error' test states.
+                (Automatically generated if value is None)
             short_message (str): The desired short message for the test which is only used for 'skipped', 'failure',
                 'error' test states. (Automatically generated if value is None)
 
@@ -675,6 +709,8 @@ class TestStepInfo(TestCaseInfo):
                                            duration,
                                            message,
                                            short_message,
+                                           system_err,
+                                           system_out,
                                            test_case.jira_tickets)
 
         self._parent_test_case_info = test_case

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -93,7 +93,21 @@ def default_testcase_properties():
 
 
 @pytest.fixture(scope='session')
-def single_passing_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def default_testcase_elements():
+    """Default test case properties which can be used to construct valid JUnitXML documents."""
+
+    return \
+        """
+                    <system-out>stdout</system-out>
+                    <system-err>stderr</system-err>
+        """
+
+
+@pytest.fixture(scope='session')
+def single_passing_xml(tmpdir_factory,
+                       default_global_properties,
+                       default_testcase_properties,
+                       default_testcase_elements):
     """JUnitXML sample representing a single passing test."""
 
     filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
@@ -104,9 +118,12 @@ def single_passing_xml(tmpdir_factory, default_global_properties, default_testca
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -115,7 +132,10 @@ def single_passing_xml(tmpdir_factory, default_global_properties, default_testca
 
 
 @pytest.fixture(scope='session')
-def single_fail_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def single_fail_xml(tmpdir_factory,
+                    default_global_properties,
+                    default_testcase_properties,
+                    default_testcase_elements):
     """JUnitXML sample representing a single failing test."""
 
     filename = tmpdir_factory.mktemp('data').join('single_fail.xml').strpath
@@ -133,9 +153,12 @@ def single_fail_xml(tmpdir_factory, default_global_properties, default_testcase_
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -144,7 +167,10 @@ def single_fail_xml(tmpdir_factory, default_global_properties, default_testcase_
 
 
 @pytest.fixture(scope='session')
-def single_error_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def single_error_xml(tmpdir_factory,
+                     default_global_properties,
+                     default_testcase_properties,
+                     default_testcase_elements):
     """JUnitXML sample representing a single erroring test."""
 
     filename = tmpdir_factory.mktemp('data').join('single_error.xml').strpath
@@ -155,6 +181,7 @@ def single_error_xml(tmpdir_factory, default_global_properties, default_testcase
             <testcase classname="tests.test_default" file="tests/test_default.py" line="20"
             name="test_error[ansible://localhost]" time="0.00208067893982">
                 {testcase_properties}
+
                 <error message="test setup failure">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
 
             @pytest.fixture
@@ -163,9 +190,12 @@ def single_error_xml(tmpdir_factory, default_global_properties, default_testcase
         E       RuntimeError: oops
 
         tests/test_default.py:10: RuntimeError</error>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -174,7 +204,10 @@ def single_error_xml(tmpdir_factory, default_global_properties, default_testcase
 
 
 @pytest.fixture(scope='session')
-def single_skip_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def single_skip_xml(tmpdir_factory,
+                    default_global_properties,
+                    default_testcase_properties,
+                    default_testcase_elements):
     """JUnitXML sample representing a single skipping test."""
 
     filename = tmpdir_factory.mktemp('data').join('single_skip.xml').strpath
@@ -188,9 +221,12 @@ def single_skip_xml(tmpdir_factory, default_global_properties, default_testcase_
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -199,7 +235,10 @@ def single_skip_xml(tmpdir_factory, default_global_properties, default_testcase_
 
 
 @pytest.fixture(scope='session')
-def flat_all_passing_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def flat_all_passing_xml(tmpdir_factory,
+                         default_global_properties,
+                         default_testcase_properties,
+                         default_testcase_elements):
     """JUnitXML sample representing multiple passing test cases."""
 
     filename = tmpdir_factory.mktemp('data').join('flat_all_passing.xml').strpath
@@ -210,25 +249,32 @@ def flat_all_passing_xml(tmpdir_factory, default_global_properties, default_test
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass1[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="12"
             name="test_pass2[ansible://localhost]" time="0.00341415405273">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="15"
             name="test_pass3[ansible://localhost]" time="0.00363945960999">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="18"
             name="test_pass4[ansible://localhost]" time="0.00314617156982">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="21"
             name="test_pass5[ansible://localhost]" time="0.00332307815552">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -237,7 +283,10 @@ def flat_all_passing_xml(tmpdir_factory, default_global_properties, default_test
 
 
 @pytest.fixture(scope='session')
-def suite_all_passing_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def suite_all_passing_xml(tmpdir_factory,
+                          default_global_properties,
+                          default_testcase_properties,
+                          default_testcase_elements):
     """JUnitXML sample representing multiple passing test cases in a test suite. (Tests within a Python class)"""
 
     filename = tmpdir_factory.mktemp('data').join('suite_all_passing.xml').strpath
@@ -248,25 +297,32 @@ def suite_all_passing_xml(tmpdir_factory, default_global_properties, default_tes
             <testcase classname="tests.test_default.TestSuite" file="tests/test_default.py" line="8"
             name="test_pass1[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestSuite" file="tests/test_default.py" line="12"
             name="test_pass2[ansible://localhost]" time="0.00341415405273">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestSuite" file="tests/test_default.py" line="15"
             name="test_pass3[ansible://localhost]" time="0.00363945960999">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestSuite" file="tests/test_default.py" line="18"
             name="test_pass4[ansible://localhost]" time="0.00314617156982">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestSuite" file="tests/test_default.py" line="21"
             name="test_pass5[ansible://localhost]" time="0.00332307815552">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -275,7 +331,10 @@ def suite_all_passing_xml(tmpdir_factory, default_global_properties, default_tes
 
 
 @pytest.fixture(scope='session')
-def flat_mix_status_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def flat_mix_status_xml(tmpdir_factory,
+                        default_global_properties,
+                        default_testcase_properties,
+                        default_testcase_elements):
     """JUnitXML sample representing mixed status for multiple test cases."""
 
     filename = tmpdir_factory.mktemp('data').join('flat_mix_status.xml').strpath
@@ -286,6 +345,7 @@ def flat_mix_status_xml(tmpdir_factory, default_global_properties, default_testc
             <testcase classname="tests.test_default" file="tests/test_default.py" line="12"
             name="test_pass[ansible://localhost]" time="0.0034921169281">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
             name="test_fail[ansible://localhost]" time="0.00335693359375">
@@ -297,6 +357,7 @@ def flat_mix_status_xml(tmpdir_factory, default_global_properties, default_testc
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="20"
             name="test_error[ansible://localhost]" time="0.00208067893982">
@@ -309,6 +370,7 @@ def flat_mix_status_xml(tmpdir_factory, default_global_properties, default_testc
         E       RuntimeError: oops
 
         tests/test_default.py:10: RuntimeError</error>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="24"
             name="test_skip[ansible://localhost]" time="0.00197100639343">
@@ -316,9 +378,12 @@ def flat_mix_status_xml(tmpdir_factory, default_global_properties, default_testc
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -377,7 +442,7 @@ def missing_testcase_properties_xml(tmpdir_factory, default_global_properties):
 
 
 @pytest.fixture(scope='session')
-def missing_test_id_xml(tmpdir_factory, default_global_properties):
+def missing_test_id_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing a test case that has a missing test id property element."""
 
     filename = tmpdir_factory.mktemp('data').join('missing_test_id.xml').strpath
@@ -392,8 +457,9 @@ def missing_test_id_xml(tmpdir_factory, default_global_properties):
                     <property name="start_time" value="2018-04-10T21:38:18Z"/>
                     <property name="end_time" value="2018-04-10T21:38:19Z"/>
                 </properties>
+                {testcase_elements}
         </testsuite>
-        """.format(global_properties=default_global_properties)
+        """.format(global_properties=default_global_properties, testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -402,7 +468,7 @@ def missing_test_id_xml(tmpdir_factory, default_global_properties):
 
 
 @pytest.fixture(scope='session')
-def missing_build_url_xml(tmpdir_factory, default_testcase_properties):
+def missing_build_url_xml(tmpdir_factory, default_testcase_properties, default_testcase_elements):
     """JUnitXML sample representing a test suite that is missing the "BUILD_URL" property."""
 
     filename = tmpdir_factory.mktemp('data').join('missing_build_url.xml').strpath
@@ -426,8 +492,9 @@ def missing_build_url_xml(tmpdir_factory, default_testcase_properties):
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852"/>
                 {testcase_properties}
+                {testcase_elements}
         </testsuite>
-        """.format(testcase_properties=default_testcase_properties)
+        """.format(testcase_properties=default_testcase_properties, testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -436,7 +503,10 @@ def missing_build_url_xml(tmpdir_factory, default_testcase_properties):
 
 
 @pytest.fixture(scope='session')
-def classname_with_dashes_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def classname_with_dashes_xml(tmpdir_factory,
+                              default_global_properties,
+                              default_testcase_properties,
+                              default_testcase_elements):
     """JUnitXML sample representing a testcase that has a 'classname' attribute which contains dashes for the py.test
     filename."""
 
@@ -449,9 +519,12 @@ def classname_with_dashes_xml(tmpdir_factory, default_global_properties, default
             file="tests/test_for_acs-150.py" line="140"
             name="test_verify_kibana_horizon_access_with_no_ssh[_testinfra_host0]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -460,7 +533,10 @@ def classname_with_dashes_xml(tmpdir_factory, default_global_properties, default
 
 
 @pytest.fixture(scope='session')
-def invalid_classname_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+def invalid_classname_xml(tmpdir_factory,
+                          default_global_properties,
+                          default_testcase_properties,
+                          default_testcase_elements):
     """JUnitXML sample representing a testcase that has an invalid 'classname' attribute which is used to build the
     results hierarchy in the '_generate_module_hierarchy' function."""
 
@@ -472,9 +548,12 @@ def invalid_classname_xml(tmpdir_factory, default_global_properties, default_tes
             <testcase classname="this is not a valid classname" file="tests/test_default.py" line="8"
             name="test_pass[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)

--- a/tests/unit/test_zigzag.py
+++ b/tests/unit/test_zigzag.py
@@ -422,7 +422,7 @@ class TestParseXMLtoTestLogs(object):
         # Expectation
         attachment_exp_name_regex = re.compile(r'^junit_.+\.xml$')
         attachment_exp_content_type = 'application/xml'
-        attachment_exp_data_md5 = '4128ed80ee5728281c987bc251551ad4'
+        attachment_exp_data_md5 = 'f3b2303ccf8a76a9e20d2099e9b2f29c'
 
         # Test
         assert attachment_exp_name_regex.match(test_log_dict['attachments'][0]['name']) is not None

--- a/tests/unit/test_zigzag_test_log.py
+++ b/tests/unit/test_zigzag_test_log.py
@@ -57,18 +57,17 @@ def mock_zigzag(mocker):
 
 
 @pytest.fixture(scope='module')
-def short_single_line_failure_message(tmpdir_factory, default_global_properties, default_testcase_properties):
-    """Failing test case with a short single line failure message."""
+def single_passing_no_sys_capture_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+    """A single passing test that does not have 'system-out' or 'system-err' testcase elements."""
 
-    filename = tmpdir_factory.mktemp('data').join('short_single_line_failure_message.xml').strpath
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
     junit_xml = \
         """<?xml version="1.0" encoding="utf-8"?>
         <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
             {global_properties}
-            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
-            name="test_fail[ansible://localhost]" time="0.00335693359375">
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
+            name="test_pass[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
-                <failure message="short">Short</failure>
             </testcase>
         </testsuite>
         """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
@@ -80,7 +79,140 @@ def short_single_line_failure_message(tmpdir_factory, default_global_properties,
 
 
 @pytest.fixture(scope='module')
-def long_single_line_failure_message(tmpdir_factory, default_global_properties, default_testcase_properties):
+def single_failing_no_sys_capture_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+    """A single failing test that does not have 'system-out' or 'system-err' testcase elements."""
+
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="fail">Fail</failure>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_failing_duplicate_sys_capture_xml(tmpdir_factory,
+                                             default_global_properties,
+                                             default_testcase_properties,
+                                             default_testcase_elements):
+    """A single failing test that has duplicate 'system-out' and 'system-err' testcase elements."""
+
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="fail">Fail</failure>
+                {testcase_elements}
+                {testcase_elements}
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_failing_missing_sys_err_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+    """A single failing test that does not have 'system-err' testcase element."""
+
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="fail">Fail</failure>
+                <system-out>stdout</system-out>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_failing_missing_sys_out_xml(tmpdir_factory, default_global_properties, default_testcase_properties):
+    """A single failing test that does not have 'system-out' testcase element."""
+
+    filename = tmpdir_factory.mktemp('data').join('single_passing.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="fail">Fail</failure>
+                <system-err>stderr</system-err>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties, testcase_properties=default_testcase_properties)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def short_single_line_failure_message(tmpdir_factory,
+                                      default_global_properties,
+                                      default_testcase_properties,
+                                      default_testcase_elements):
+    """Failing test case with a short single line failure message."""
+
+    filename = tmpdir_factory.mktemp('data').join('short_single_line_failure_message.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+        <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default" file="tests/test_default.py" line="16"
+            name="test_fail[ansible://localhost]" time="0.00335693359375">
+                {testcase_properties}
+                <failure message="short">Short</failure>
+                {testcase_elements}
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=default_testcase_properties,
+                   testcase_elements=default_testcase_elements)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def long_single_line_failure_message(tmpdir_factory,
+                                     default_global_properties,
+                                     default_testcase_properties,
+                                     default_testcase_elements):
     """Failing test case with a long (153 characters) single line failure message."""
 
     filename = tmpdir_factory.mktemp('data').join('long_single_line_failure_message.xml').strpath
@@ -92,11 +224,13 @@ def long_single_line_failure_message(tmpdir_factory, default_global_properties, 
             name="test_fail[ansible://localhost]" time="0.00335693359375">
                 {testcase_properties}
                 <failure message="long">{failure_message}</failure>
+                {testcase_elements}
             </testcase>
         </testsuite>
         """.format(global_properties=default_global_properties,
                    testcase_properties=default_testcase_properties,
-                   failure_message=LONG_FAILURE_MESSAGE)
+                   failure_message=LONG_FAILURE_MESSAGE,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -105,7 +239,10 @@ def long_single_line_failure_message(tmpdir_factory, default_global_properties, 
 
 
 @pytest.fixture(scope='module')
-def long_multi_line_failure_message(tmpdir_factory, default_global_properties, default_testcase_properties):
+def long_multi_line_failure_message(tmpdir_factory,
+                                    default_global_properties,
+                                    default_testcase_properties,
+                                    default_testcase_elements):
     """Failing test case with 7 long (153 characters) lines in failure message."""
 
     filename = tmpdir_factory.mktemp('data').join('long_multi_line_failure_message.xml').strpath
@@ -125,11 +262,13 @@ def long_multi_line_failure_message(tmpdir_factory, default_global_properties, d
                     {failure_message}
                     {failure_message}
                 </failure>
+                {testcase_elements}
             </testcase>
         </testsuite>
         """.format(global_properties=default_global_properties,
                    testcase_properties=default_testcase_properties,
-                   failure_message=LONG_FAILURE_MESSAGE)
+                   failure_message=LONG_FAILURE_MESSAGE,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -138,8 +277,67 @@ def long_multi_line_failure_message(tmpdir_factory, default_global_properties, d
 
 
 @pytest.fixture(scope='module')
-def single_test_with_mixed_status_steps_xml(tmpdir_factory, default_global_properties):
+def single_test_with_mixed_status_steps_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing a single test case with multiple steps."""
+
+    test_step_testcase_properties = \
+        """
+                    <properties>
+                        <property name="jira" value="ASC-123"/>
+                        <property name="test_id" value="1"/>
+                        <property name="test_step" value="true"/>
+                        <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                        <property name="end_time" value="2018-04-10T21:38:19Z"/>
+                    </properties>
+        """
+
+    filename = tmpdir_factory.mktemp('data').join('single_test_with_mixed_status_steps.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+            <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="8"
+            name="test_step_pass[ansible://localhost]" time="0.00372695922852">
+                {testcase_properties}
+                {testcase_elements}
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="12"
+            name="test_step_fail[ansible://localhost]" time="0.00341415405273">
+                {testcase_properties}
+                <failure message="assert False">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
+
+            def test_fail(host):
+        &gt;       assert False
+        E       assert False
+
+        tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
+            name="test_step_skip[ansible://localhost]" time="0.00363945960999">
+                {testcase_properties}
+                <skipped message="unconditional skip" type="pytest.skip">
+                    tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
+                </skipped>
+                {testcase_elements}
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=test_step_testcase_properties,
+                   testcase_name='TestCaseWithSteps',
+                   testcase_elements=default_testcase_elements)
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_test_with_mixed_status_steps_no_sys_capture_xml(tmpdir_factory, default_global_properties):
+    """JUnitXML sample representing a single test case with multiple steps. The failing step does not have
+    'system-err' or 'system-out' elements.
+    """
 
     test_step_testcase_properties = \
         """
@@ -191,7 +389,119 @@ def single_test_with_mixed_status_steps_xml(tmpdir_factory, default_global_prope
 
 
 @pytest.fixture(scope='module')
-def single_test_with_multiple_skipping_steps_xml(tmpdir_factory, default_global_properties):
+def single_test_with_mixed_status_steps_missing_sys_err_xml(tmpdir_factory, default_global_properties):
+    """JUnitXML sample representing a single test case with multiple steps. The failing step does not have
+    the 'system-err' element.
+    """
+
+    test_step_testcase_properties = \
+        """
+                    <properties>
+                        <property name="jira" value="ASC-123"/>
+                        <property name="test_id" value="1"/>
+                        <property name="test_step" value="true"/>
+                        <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                        <property name="end_time" value="2018-04-10T21:38:19Z"/>
+                    </properties>
+        """
+
+    filename = tmpdir_factory.mktemp('data').join('single_test_with_mixed_status_steps.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+            <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="8"
+            name="test_step_pass[ansible://localhost]" time="0.00372695922852">
+                {testcase_properties}
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="12"
+            name="test_step_fail[ansible://localhost]" time="0.00341415405273">
+                {testcase_properties}
+                <failure message="assert False">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
+
+            def test_fail(host):
+        &gt;       assert False
+        E       assert False
+
+        tests/test_default.py:18: AssertionError</failure>
+                <system-out>stdout</system-out>
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
+            name="test_step_skip[ansible://localhost]" time="0.00363945960999">
+                {testcase_properties}
+                <skipped message="unconditional skip" type="pytest.skip">
+                    tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
+                </skipped>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=test_step_testcase_properties,
+                   testcase_name='TestCaseWithSteps')
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_test_with_mixed_status_steps_missing_sys_out_xml(tmpdir_factory, default_global_properties):
+    """JUnitXML sample representing a single test case with multiple steps. The failing step does not have
+    the 'system-out' element.
+    """
+
+    test_step_testcase_properties = \
+        """
+                    <properties>
+                        <property name="jira" value="ASC-123"/>
+                        <property name="test_id" value="1"/>
+                        <property name="test_step" value="true"/>
+                        <property name="start_time" value="2018-04-10T21:38:18Z"/>
+                        <property name="end_time" value="2018-04-10T21:38:19Z"/>
+                    </properties>
+        """
+
+    filename = tmpdir_factory.mktemp('data').join('single_test_with_mixed_status_steps.xml').strpath
+    junit_xml = \
+        """<?xml version="1.0" encoding="utf-8"?>
+            <testsuite errors="0" failures="0" name="pytest" skips="0" tests="5" time="1.664">
+            {global_properties}
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="8"
+            name="test_step_pass[ansible://localhost]" time="0.00372695922852">
+                {testcase_properties}
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="12"
+            name="test_step_fail[ansible://localhost]" time="0.00341415405273">
+                {testcase_properties}
+                <failure message="assert False">host = &lt;testinfra.host.Host object at 0x7f0921d98cd0&gt;
+
+            def test_fail(host):
+        &gt;       assert False
+        E       assert False
+
+        tests/test_default.py:18: AssertionError</failure>
+                <system-err>stderr</system-err>
+            </testcase>
+            <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
+            name="test_step_skip[ansible://localhost]" time="0.00363945960999">
+                {testcase_properties}
+                <skipped message="unconditional skip" type="pytest.skip">
+                    tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
+                </skipped>
+            </testcase>
+        </testsuite>
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=test_step_testcase_properties,
+                   testcase_name='TestCaseWithSteps')
+
+    with open(filename, 'w') as f:
+        f.write(junit_xml)
+
+    return filename
+
+
+@pytest.fixture(scope='module')
+def single_test_with_multiple_skipping_steps_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing a single test case with multiple skipping steps."""
 
     test_step_testcase_properties = \
@@ -216,6 +526,7 @@ def single_test_with_multiple_skipping_steps_xml(tmpdir_factory, default_global_
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
             name="test_skip_step[ansible://localhost]" time="0.00363945960999">
@@ -223,11 +534,13 @@ def single_test_with_multiple_skipping_steps_xml(tmpdir_factory, default_global_
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
         </testsuite>
         """.format(global_properties=default_global_properties,
                    testcase_properties=test_step_testcase_properties,
-                   testcase_name='TestCaseWithSteps')
+                   testcase_name='TestCaseWithSteps',
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -236,7 +549,7 @@ def single_test_with_multiple_skipping_steps_xml(tmpdir_factory, default_global_
 
 
 @pytest.fixture(scope='module')
-def single_test_with_multiple_passing_steps_xml(tmpdir_factory, default_global_properties):
+def single_test_with_multiple_passing_steps_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing a single test case with multiple passing steps."""
 
     test_step_testcase_properties = \
@@ -258,15 +571,18 @@ def single_test_with_multiple_passing_steps_xml(tmpdir_factory, default_global_p
             <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
             name="test_pass_step[ansible://localhost]" time="0.00363945960999">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.{testcase_name}" file="tests/test_default.py" line="15"
             name="test_pass_step[ansible://localhost]" time="0.00363945960999">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
         </testsuite>
         """.format(global_properties=default_global_properties,
                    testcase_properties=test_step_testcase_properties,
-                   testcase_name='TestCaseWithSteps')
+                   testcase_name='TestCaseWithSteps',
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -275,7 +591,7 @@ def single_test_with_multiple_passing_steps_xml(tmpdir_factory, default_global_p
 
 
 @pytest.fixture(scope='module')
-def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_properties):
+def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing multiple test cases with various statuses along with a single step each."""
 
     test_step_testcase_properties = \
@@ -297,6 +613,7 @@ def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_pro
             <testcase classname="tests.test_default.TestCasePass" file="tests/test_default.py" line="8"
             name="test_step_pass[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseFail" file="tests/test_default.py" line="12"
             name="test_step_fail[ansible://localhost]" time="0.00341415405273">
@@ -308,6 +625,7 @@ def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_pro
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseSkip" file="tests/test_default.py" line="15"
             name="test_step_skip[ansible://localhost]" time="0.00363945960999">
@@ -315,9 +633,12 @@ def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_pro
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=test_step_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=test_step_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -326,7 +647,7 @@ def multiple_mixed_status_tests_with_step_xml(tmpdir_factory, default_global_pro
 
 
 @pytest.fixture(scope='module')
-def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_properties):
+def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing multiple test cases with various statuses along with multiple steps each."""
 
     test_step_testcase_properties = \
@@ -348,10 +669,12 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
             <testcase classname="tests.test_default.TestCasePass" file="tests/test_default.py" line="8"
             name="test_pass_step_0[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCasePass" file="tests/test_default.py" line="8"
             name="test_pass_step_1[ansible://localhost]" time="0.00372695922852">
                 {testcase_properties}
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseFail" file="tests/test_default.py" line="12"
             name="test_fail_step_0[ansible://localhost]" time="0.00341415405273">
@@ -363,6 +686,7 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseFail" file="tests/test_default.py" line="12"
             name="test_fail_step_1[ansible://localhost]" time="0.00341415405273">
@@ -374,6 +698,7 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
         E       assert False
 
         tests/test_default.py:18: AssertionError</failure>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseSkip" file="tests/test_default.py" line="15"
             name="test_skip_step_0[ansible://localhost]" time="0.00363945960999">
@@ -381,6 +706,7 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default.TestCaseSkip" file="tests/test_default.py" line="15"
             name="test_skip_step_1[ansible://localhost]" time="0.00363945960999">
@@ -388,9 +714,12 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
                 <skipped message="unconditional skip" type="pytest.skip">
                     tests/test_default.py:24: &lt;py._xmlgen.raw object at 0x7f0921ff4d50&gt;
                 </skipped>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties, testcase_properties=test_step_testcase_properties)
+        """.format(global_properties=default_global_properties,
+                   testcase_properties=test_step_testcase_properties,
+                   testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -399,7 +728,7 @@ def multiple_mixed_status_tests_with_steps_xml(tmpdir_factory, default_global_pr
 
 
 @pytest.fixture(scope='module')
-def multiple_tests_with_and_without_steps_xml(tmpdir_factory, default_global_properties):
+def multiple_tests_with_and_without_steps_xml(tmpdir_factory, default_global_properties, default_testcase_elements):
     """JUnitXML sample representing a mix of test cases with and without steps."""
 
     filename = tmpdir_factory.mktemp('data').join('multiple_tests_with_and_without_steps.xml').strpath
@@ -416,6 +745,7 @@ def multiple_tests_with_and_without_steps_xml(tmpdir_factory, default_global_pro
                     <property name="start_time" value="2018-04-10T21:38:18Z"/>
                     <property name="end_time" value="2018-04-10T21:38:19Z"/>
                 </properties>
+                {testcase_elements}
             </testcase>
             <testcase classname="tests.test_default" file="tests/test_default.py" line="8"
             name="test_case_without_steps[ansible://localhost]" time="0.00372695922852">
@@ -426,9 +756,10 @@ def multiple_tests_with_and_without_steps_xml(tmpdir_factory, default_global_pro
                     <property name="start_time" value="2018-04-10T21:38:18Z"/>
                     <property name="end_time" value="2018-04-10T21:38:19Z"/>
                 </properties>
+                {testcase_elements}
             </testcase>
         </testsuite>
-        """.format(global_properties=default_global_properties)
+        """.format(global_properties=default_global_properties, testcase_elements=default_testcase_elements)
 
     with open(filename, 'w') as f:
         f.write(junit_xml)
@@ -442,6 +773,23 @@ def multiple_tests_with_and_without_steps_xml(tmpdir_factory, default_global_pro
 # noinspection PyProtectedMember
 class TestZigZagTestLog(object):
     """Tests for the _ZigZagTestLog class through the ZigZagTestLogs public class."""
+
+    def test_single_passing_no_sys_capture(self, single_passing_no_sys_capture_xml, mock_zigzag):
+        """Test that nothing blows up if the JUnitXML testcase element lacks 'system-out' and 'system-err' elements."""
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_passing_no_sys_capture_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Expectations
+        qtest_id_exp = 5678
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]   # Create a new TestLog object through the ZigZagTestLogs public class
+        assert not tl.stderr
+        assert not tl.stdout
+        assert tl.qtest_testcase_id == qtest_id_exp
 
     def test_lookup_ids(self, single_passing_xml, mock_zigzag):
         """Test for _lookup_ids happy path"""
@@ -544,6 +892,8 @@ class TestZigZagTestLog(object):
 
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert tl.stderr == 'stderr'
+        assert tl.stdout == 'stdout'
 
         # there should be a list of two attachments: the junit xml
         # file and a text log
@@ -792,6 +1142,32 @@ class TestFailedTestCases(object):
 
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert tl.stderr == 'stderr'
+        assert tl.stdout == 'stdout'
+
+        # there should be a list of two attachments: the junit xml
+        # file and a text log
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 4
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+    def test_failed_test_case_attachments_no_sys_capture(self, single_failing_no_sys_capture_xml, mock_zigzag):
+        """Test to ensure that the correct test artifacts are being attached when the JUnitXML testcase element does
+        not contain 'system-err' or 'system-out' elements.
+        """
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_failing_no_sys_capture_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert not tl.stderr
+        assert not tl.stdout
 
         # there should be a list of two attachments: the junit xml
         # file and a text log
@@ -799,6 +1175,81 @@ class TestFailedTestCases(object):
         assert len(tl.qtest_test_log.attachments) == 2
         assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
         assert tl.qtest_test_log.attachments[1].content_type == 'text/plain'
+
+    def test_failed_test_case_attachments_duplicate_sys_capture(self,
+                                                                single_failing_duplicate_sys_capture_xml,
+                                                                mock_zigzag):
+        """Test to ensure that the correct test artifacts are being attached when the JUnitXML testcase element has
+        duplicate 'system-err' and 'system-out' elements. Expected behavior is to select the first set of elements for
+        data extraction. (See ASC-1141)
+        """
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_failing_duplicate_sys_capture_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert tl.stderr == 'stderr'
+        assert tl.stdout == 'stdout'
+
+        # there should be a list of two attachments: the junit xml
+        # file and a text log
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 4
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+    def test_failed_test_case_attachments_missing_sys_err(self, single_failing_missing_sys_err_xml, mock_zigzag):
+        """Test to ensure that the correct test artifacts are being attached when the JUnitXML testcase element does
+        not contain the 'system-err' element.
+        """
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_failing_missing_sys_err_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert not tl.stderr
+        assert tl.stdout == 'stdout'
+
+        # there should be a list of two attachments: the junit xml
+        # file and a text log
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 3
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+    def test_failed_test_case_attachments_missing_sys_out(self, single_failing_missing_sys_out_xml, mock_zigzag):
+        """Test to ensure that the correct test artifacts are being attached when the JUnitXML testcase element does
+        not contain the 'system-out' element.
+        """
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_failing_missing_sys_out_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
+        assert tl.stderr == 'stderr'
+        assert not tl.stdout
+
+        # there should be a list of two attachments: the junit xml
+        # file and a text log
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 3
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
 
     def test_failed_test_step_attachments(self, single_test_with_mixed_status_steps_xml, mock_zigzag):
         """Test to ensure that test artifacts are being correctly attached to test steps upon failure."""
@@ -810,8 +1261,40 @@ class TestFailedTestCases(object):
 
         # Test
         tl = ZigZagTestLogs(zz)[0]
+        assert tl.stderr == 'stderr'
+        assert tl.stdout == 'stdout'
 
-        # The test log should have the junit xml file and a failure text log attached.
+        # The test log should have the junit xml file, failure, stderr and stdout text logs attached.
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 4
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+        # The failing step should have a failure log, stderr and stdout text logs attached.
+        failing_step = tl.qtest_test_log.test_step_logs[1]      # Failing step at known location.
+        assert len(failing_step.attachments) == 3
+
+        for failing_test_log_attachment in failing_step.attachments:
+            assert failing_test_log_attachment.content_type == 'text/plain'
+
+    def test_failed_test_step_attachments_no_sys_capture(self,
+                                                         single_test_with_mixed_status_steps_no_sys_capture_xml,
+                                                         mock_zigzag):
+        """Test to ensure that test artifacts are being correctly attached to test steps upon failure."""
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_test_with_mixed_status_steps_no_sys_capture_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]
+        assert not tl.stderr
+        assert not tl.stdout
+
+        # The test log should have the junit xml file and failure text log attached.
         assert isinstance(tl.qtest_test_log.attachments, list)
         assert len(tl.qtest_test_log.attachments) == 2
         assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
@@ -820,7 +1303,66 @@ class TestFailedTestCases(object):
         # The failing step should have a failure text log attached.
         failing_step = tl.qtest_test_log.test_step_logs[1]      # Failing step at known location.
         assert len(failing_step.attachments) == 1
-        assert failing_step.attachments[0].content_type == 'text/plain'
+
+    def test_failed_test_step_attachments_missing_sys_err_xml(self,
+                                                              single_test_with_mixed_status_steps_missing_sys_err_xml,
+                                                              mock_zigzag):
+        """Test to ensure that test artifacts are being correctly attached to test steps upon failure."""
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_test_with_mixed_status_steps_missing_sys_err_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]
+        assert not tl.stderr
+        assert tl.stdout == 'stdout'
+
+        # The test log should have the junit xml file, failure and stdout text logs attached.
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 3
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+        # The failing test log should have the junit xml file, failure and stdout text logs attached.
+        failing_step = tl.qtest_test_log.test_step_logs[1]      # Failing step at known location.
+        assert len(failing_step.attachments) == 2
+
+        for failing_test_log_attachment in failing_step.attachments:
+            assert failing_test_log_attachment.content_type == 'text/plain'
+
+    def test_failed_test_step_attachments_missing_sys_out_xml(self,
+                                                              single_test_with_mixed_status_steps_missing_sys_out_xml,
+                                                              mock_zigzag):
+        """Test to ensure that test artifacts are being correctly attached to test steps upon failure."""
+
+        # Setup
+        mock_zigzag()
+        zz = ZigZag(single_test_with_mixed_status_steps_missing_sys_out_xml, TOKEN, PROJECT_ID, TEST_CYCLE)
+        zz.parse()
+
+        # Test
+        tl = ZigZagTestLogs(zz)[0]
+        assert tl.stderr == 'stderr'
+        assert not tl.stdout
+
+        # The test log should have the junit xml file, failure and stderr text logs attached.
+        assert isinstance(tl.qtest_test_log.attachments, list)
+        assert len(tl.qtest_test_log.attachments) == 3
+        assert tl.qtest_test_log.attachments[0].content_type == 'application/xml'
+
+        for test_log_attachment in tl.qtest_test_log.attachments[1:]:
+            assert test_log_attachment.content_type == 'text/plain'
+
+            # The failing test log should have the junit xml file, failure and stderr text logs attached.
+        failing_step = tl.qtest_test_log.test_step_logs[1]      # Failing step at known location.
+        assert len(failing_step.attachments) == 2
+
+        for failing_test_log_attachment in failing_step.attachments:
+            assert failing_test_log_attachment.content_type == 'text/plain'
 
     def test_truncated_failure_output(self, single_fail_xml, mock_zigzag):
         """Test to ensure that log messages are truncated correctly"""


### PR DESCRIPTION
When a test fails the output captured from 'stderr' and/or 'stdout' will be
attached to the qTest result. If nothing is populated in 'stderr' or 'stdout'
then nothing will be attached.

I successfully ran the changes through Integration tests on Python 2.7 and 3.5.