### PR TITLE
ASC-1199 refactor _ZigZagTestLog

### DIFF
--- a/tests/integration/test_steps.py
+++ b/tests/integration/test_steps.py
@@ -266,5 +266,5 @@ class TestSteps(object):
         # Test
         assert len(test_runs) == 1
         assert len(mixed_status_test_steps_for_mk8s.tests) == 3
-        #pytest.helpers.assert_qtest_property(test_runs[0], 'Status', test_run_status_exp)
+        pytest.helpers.assert_qtest_property(test_runs[0], 'Status', test_run_status_exp)
         pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)

--- a/tests/integration/test_steps.py
+++ b/tests/integration/test_steps.py
@@ -266,5 +266,5 @@ class TestSteps(object):
         # Test
         assert len(test_runs) == 1
         assert len(mixed_status_test_steps_for_mk8s.tests) == 3
-        pytest.helpers.assert_qtest_property(test_runs[0], 'Status', test_run_status_exp)
+        #pytest.helpers.assert_qtest_property(test_runs[0], 'Status', test_run_status_exp)
         pytest.helpers.assert_qtest_property_search(test_runs[0], 'Failure Output', test_failure_msg_regex_exp)

--- a/tests/unit/test_zigzag_test_log.py
+++ b/tests/unit/test_zigzag_test_log.py
@@ -1375,7 +1375,7 @@ class TestFailedTestCases(object):
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
 
-        assert len(tl._failure_output.split('\n')) == 4
+        assert len(tl.failure_output.split('\n')) == 4
 
     def test_truncated_failure_output_with_short_single_line_message(self, short_single_line_failure_message,
                                                                      mock_zigzag):
@@ -1389,7 +1389,7 @@ class TestFailedTestCases(object):
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
 
-        assert tl._failure_output == 'Short'
+        assert tl.failure_output == 'Short'
 
     def test_truncated_failure_output_with_long_single_line_message(self, long_single_line_failure_message,
                                                                     mock_zigzag):
@@ -1403,7 +1403,7 @@ class TestFailedTestCases(object):
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
 
-        assert tl._failure_output == LONG_FAILURE_MESSAGE[:120] + '...'
+        assert tl.failure_output == LONG_FAILURE_MESSAGE[:120] + '...'
 
     def test_truncated_failure_output_with_long_multi_line_message(self, long_multi_line_failure_message, mock_zigzag):
         """Verify that a failure output of only one line will NOT be truncated."""
@@ -1416,6 +1416,6 @@ class TestFailedTestCases(object):
         # Test
         tl = ZigZagTestLogs(zz)[0]  # Create a new TestLog object through the ZigZagTestLogs public class
 
-        assert len(tl._failure_output.split('\n')) == 4
+        assert len(tl.failure_output.split('\n')) == 4
         assert 'Log truncated' in tl._failure_output
         assert '{}{}'.format(LONG_FAILURE_MESSAGE[:100], '...') in tl._failure_output

--- a/zigzag/zigzag_test_log.py
+++ b/zigzag/zigzag_test_log.py
@@ -728,14 +728,12 @@ class _ZigZagTestLogWithSteps(_ZigZagTestLog):
             str: The output from failure or error of this test execution
         """
         if self._failure_output is None:
-            if self._status == 'FAILED':
-                for log in self._zz_test_step_logs:
-                    if log.status == 'FAILED':
-                        self._failure_output = log.failure_output
-                        break  # take the first failure_output
-            else:
-                self._failure_output = ''
+            for log in self._zz_test_step_logs:
+                if log.status == 'FAILED':
+                    self._failure_output = log.failure_output
+                    return self._failure_output  # take the first full_failure_output
 
+        self._failure_output = ''
         return self._failure_output
 
     @property


### PR DESCRIPTION
- refactors classes related to _ZigZagTestLog
- removes _parse methods
- makes properties lazy load (saves us from having to worry about order of operations)
- caches the values of some of the properties