### PR TITLE
ASC-1280 Document "zigzag" Configuration Mechanism

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Quick Start Guide
 4. Here is an example of uploading a results JUnitXML file from Molecule::
 
     $ export QTEST_API_TOKEN="SECRET"
-    $ zigzag junit.xml config.json
+    $ zigzag /path/to/config.json /path/to/junit.xml
 
 5. Checkout QA Symphony's website for more details on configuring `qTest Manager API`_ access.
 


### PR DESCRIPTION
Most of the documentation was already added as part of
f2a38d59b60960cc3a5bae05fc749820b2dd6f19

While reviewing that change I found that the arguments
in the command line example are reversed. This commit
fixes that example.