### PR TITLE
repro for missing build_url prop error

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,6 +25,20 @@ def single_passing_test_for_asc(_zigzag_runner_factory, asc_config_file, asc_glo
 
 
 @pytest.fixture(scope='session')
+def single_passing_test_with_custom_mod_hierarchy(_zigzag_runner_factory, custom_hierarchy_config_file, asc_global_props):
+    """ZigZag CLI runner configured for the "asc" CI environment with one passing test in the JUnitXML file.
+
+    Returns:
+        ZigZagRunner
+    """
+
+    zz_runner = _zigzag_runner_factory('single_passing_asc.xml', custom_hierarchy_config_file, asc_global_props)
+    zz_runner.add_test_case('passed')
+
+    return zz_runner
+
+
+@pytest.fixture(scope='session')
 def single_passing_test_for_mk8s(_zigzag_runner_factory, mk8s_config_file, mk8s_global_props):
     """ZigZag CLI runner configured for the "mk8s" CI environment with one passing test in the JUnitXML file.
 
@@ -247,6 +261,35 @@ def single_passing_test_step_for_mk8s(_zigzag_runner_factory, mk8s_config_file, 
 
 
 @pytest.fixture(scope='session')
+def custom_hierarchy_config_file(tmpdir_factory):
+    """A config for zigzag used by the ASC team
+
+    Returns:
+        str : a path to a config file
+    """
+
+    filename = tmpdir_factory.mktemp('data').join('config_file.json').strpath
+    config_json = \
+        """{
+              "pytest_zigzag_env_vars": {
+              },
+              "zigzag": {
+                "test_cycle": "{{ ZZ_INTEGRATION_TEST_CYCLE }}",
+                "project_id": "{{ ZZ_INTEGRATION_PROJECT_ID }}",
+                "module_hierarchy": [
+                  "node1",
+                  "node2"
+                ]
+              }
+            }"""
+
+    with open(filename, 'w') as f:
+        f.write(config_json)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
 def asc_config_file(tmpdir_factory):
     """A config for zigzag used by the ASC team
 
@@ -283,7 +326,7 @@ def asc_config_file(tmpdir_factory):
                 "project_id": "{{ ZZ_INTEGRATION_PROJECT_ID }}",
                 "module_hierarchy": [
                   "{{ RPC_PRODUCT_RELEASE }}",
-                  "{ {RPC_RELEASE }}",
+                  "{{ RPC_RELEASE }}",
                   "{{ JOB_NAME }}",
                   "{{ MOLECULE_TEST_REPO }}",
                   "{{ zz_testcase_class }}"

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -7,6 +7,109 @@
 # ======================================================================================================================
 import uuid
 import pytest
+from zigzag.zigzag_config import ZigZagConfigError
+from tests.helper.classes.zigzag_runner import ZigZagRunner
+
+
+# ======================================================================================================================
+# Fixtures
+# ======================================================================================================================
+
+@pytest.fixture(scope='session')
+def no_test_cycle_config(tmpdir_factory):
+    """A configuration missing the test_cycle config
+    """
+
+    filename = tmpdir_factory.mktemp('data').join('config_file.json').strpath
+    config_json = \
+        """{
+              "zigzag": {
+                "project_id": "{{ ZZ_INTEGRATION_PROJECT_ID }}",
+                "module_hierarchy": [
+                  "{{ RPC_PRODUCT_RELEASE }}",
+                  "{{ RPC_RELEASE }}",
+                  "{{ JOB_NAME }}",
+                  "{{ MOLECULE_TEST_REPO }}",
+                  "{{ zz_testcase_class }}"
+                ]
+              }
+            }"""
+
+    with open(filename, 'w') as f:
+        f.write(config_json)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
+def no_module_hierarchy_config(tmpdir_factory):
+    """A configuration missing the test_cycle config
+    """
+
+    filename = tmpdir_factory.mktemp('data').join('config_file.json').strpath
+    config_json = \
+        """{
+              "zigzag": {
+                "test_cycle": "{{ ZZ_INTEGRATION_TEST_CYCLE }}",
+                "project_id": "{{ ZZ_INTEGRATION_PROJECT_ID }}"
+              }
+            }"""
+
+    with open(filename, 'w') as f:
+        f.write(config_json)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
+def no_project_id_config(tmpdir_factory):
+    """A configuration missing the test_cycle config
+    """
+
+    filename = tmpdir_factory.mktemp('data').join('config_file.json').strpath
+    config_json = \
+        """{
+              "zigzag": {
+                "test_cycle": "{{ ZZ_INTEGRATION_TEST_CYCLE }}",
+                "module_hierarchy": [
+                  "{{ RPC_PRODUCT_RELEASE }}",
+                  "{{ RPC_RELEASE }}",
+                  "{{ JOB_NAME }}",
+                  "{{ MOLECULE_TEST_REPO }}",
+                  "{{ zz_testcase_class }}"
+                ]
+              }
+            }"""
+
+    with open(filename, 'w') as f:
+        f.write(config_json)
+
+    return filename
+
+
+@pytest.fixture(scope='session')
+def required_configs(tmpdir_factory):
+    """A configuration with required configs
+    used to test when properties evaluate to empty things
+    """
+
+    filename = tmpdir_factory.mktemp('data').join('config_file.json').strpath
+    config_json = \
+        """{
+              "zigzag": {
+                "test_cycle": "{{ ZZ_INTEGRATION_TEST_CYCLE }}",
+                "project_id": "{{ ZZ_INTEGRATION_PROJECT_ID }}",
+                "module_hierarchy": [
+                  "{{ ZZ_MODULE_HIERARCHY_ONE }}",
+                  "{{ ZZ_MODULE_HIERARCHY_TWO }}"
+                ]
+              }
+            }"""
+
+    with open(filename, 'w') as f:
+        f.write(config_json)
+
+    return filename
 
 
 # ======================================================================================================================
@@ -31,3 +134,70 @@ class TestConfig(object):
 
         # Test
         assert(parent_test_cycle_name_exp == qtest_parent_test_cycle_name)
+
+
+class TestConfigNegative(object):
+
+    def test_missing_test_cycle(self, _zigzag_runner_factory, no_test_cycle_config, asc_global_props):
+        """Verify that an error will be raised when the test_cycle config is not present"""
+
+        zz_runner = _zigzag_runner_factory('junit.xml', no_test_cycle_config, asc_global_props)
+        zz_runner.add_test_case('passed')
+        expected_message = "'test_cycle' is a required property"
+
+        with pytest.raises(ZigZagConfigError, match=expected_message):
+            zz_runner.assert_invoke_zigzag()
+
+    def test_missing_project_id(self, _zigzag_runner_factory, no_project_id_config, asc_global_props):
+        """Verify that an error will be raised when the project_id config is not present"""
+
+        zz_runner = _zigzag_runner_factory('junit.xml', no_project_id_config, asc_global_props)
+        zz_runner.add_test_case('passed')
+        expected_message = "'project_id' is a required property"
+
+        with pytest.raises(ZigZagConfigError, match=expected_message):
+            zz_runner.assert_invoke_zigzag()
+
+    def test_missing_module_module_hierarchy(self,
+                                             _zigzag_runner_factory,
+                                             no_module_hierarchy_config,
+                                             asc_global_props):
+        """Verify that an error will be raised when the module_hierarchy config is not present"""
+
+        zz_runner = _zigzag_runner_factory('junit.xml', no_module_hierarchy_config, asc_global_props)
+        zz_runner.add_test_case('passed')
+        expected_message = "'module_hierarchy' is a required property"
+
+        with pytest.raises(ZigZagConfigError, match=expected_message):
+            zz_runner.assert_invoke_zigzag()
+
+    def test_required_property_evaluates_to_empty_string(self,
+                                                         tmpdir_factory,
+                                                         qtest_env_vars,
+                                                         _configure_test_environment,
+                                                         required_configs):
+        """This tests the scenario when a config is present in the config file but its value is not present
+
+        Example:
+            "test_cycle": "{{ I_AM_NOT_A_REAL_PROPERTY }}"
+        """
+        temp_dir = tmpdir_factory.mktemp('data')
+        props = {}
+        root_test_cycle, root_req_module = _configure_test_environment
+        junit_xml_file_path = temp_dir.join('junit.xml').strpath
+
+        zz_runner = ZigZagRunner(qtest_env_vars['QTEST_API_TOKEN'],
+                                 qtest_env_vars['QTEST_SANDBOX_PROJECT_ID'],
+                                 root_test_cycle,
+                                 root_req_module,
+                                 junit_xml_file_path,
+                                 required_configs,
+                                 props)
+
+        zz_runner.add_test_case('passed')
+
+        expected_message = "The config 'project_id' was not found in the config file"
+
+        with pytest.raises(ZigZagConfigError, match=expected_message):
+            zz_runner.assert_invoke_zigzag()
+

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+"""Test supported configurations of zigzag."""
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
+import uuid
+import pytest
+
+
+# ======================================================================================================================
+# Test Suites
+# ======================================================================================================================
+class TestConfig(object):
+    # noinspection PyUnresolvedReferences
+    def test_publish_single_passing_custom_mod_hierarchy(self, single_passing_test_with_custom_mod_hierarchy):
+        """Verify ZigZag can publish results from the "asc" CI environment with one passing test in the JUnitXML
+        file.
+        """
+
+        # Setup
+        single_passing_test_with_custom_mod_hierarchy.assert_invoke_zigzag()
+        test_runs = single_passing_test_with_custom_mod_hierarchy.tests[0].qtest_test_runs
+
+        # Expectations
+        parent_test_cycle_name_exp = 'node2'
+
+        test = single_passing_test_with_custom_mod_hierarchy.tests[0]
+        qtest_parent_test_cycle_name = test.qtest_parent_test_cycles[0].name
+
+        # Test
+        assert(parent_test_cycle_name_exp == qtest_parent_test_cycle_name)

--- a/zigzag/xml_parsing_facade.py
+++ b/zigzag/xml_parsing_facade.py
@@ -42,12 +42,6 @@ class XmlParsingFacade(object):
                                                                  encoding='UTF-8',
                                                                  xml_declaration=True)
 
-            try:
-                # TODO move this logic into lazy load properties
-                self._mediator.build_url = self._mediator.config_dict.get_config('build_url')
-                self._mediator.build_number = self._mediator.config_dict.get_config('build_number')
-            except (KeyError, ZigZagConfigError) as e:
-                raise RuntimeError("Test suite is missing the required property!\n\n{}".format(str(e)))
         elif self._mediator.test_runner == 'tempest':
             self._read(file_path)
             self._mediator.testsuite_props = {p.attrib['name']: p.attrib['value']

--- a/zigzag/zigzag.py
+++ b/zigzag/zigzag.py
@@ -13,6 +13,7 @@ from zigzag.requirements_link_facade import RequirementsLinkFacade
 from zigzag.zigzag_test_log import ZigZagTestLogError
 from zigzag.module_hierarchy_facade import ModuleHierarchyFacade
 from zigzag.zigzag_config import ZigZagConfig
+from zigzag.zigzag_config import ZigZagConfigError
 
 
 class ZigZag(object):
@@ -179,13 +180,10 @@ class ZigZag(object):
         Returns:
             str: The url for the build
         """
-        return self._build_url
-
-    @build_url.setter
-    def build_url(self, value):
-        """Sets the value for build_url
-        """
-        self._build_url = value
+        try:
+            return self.config_dict.get_config('build_url')
+        except ZigZagConfigError:
+            pass  # this is not a required property
 
     @property
     def build_number(self):
@@ -194,13 +192,10 @@ class ZigZag(object):
         Returns:
             int: the number of the build
         """
-        return self._build_number
-
-    @build_number.setter
-    def build_number(self, value):
-        """Sets the number of the build
-        """
-        self._build_number = value
+        try:
+            return self.config_dict.get_config('build_number')
+        except ZigZagConfigError:
+            pass  # this is not a required property
 
     @property
     def testsuite_props(self):


### PR DESCRIPTION
@zreichert here's that repro branch.  

should result in this error:
`E    RuntimeError: Test suite is missing the required property!   The config 'build_url' was not found in the config file`